### PR TITLE
feat(auth): Face ID login, QR spot scanner, and logout fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,296 +1,117 @@
-# Contributing Guide
+# SD Smart Parking — iOS App
 
-Thank you for taking the time to contribute! This document outlines the standards and workflows we follow to keep the codebase clean, consistent, and maintainable.
-
----
-
-## Table of Contents
-
-- [Code of Conduct](#code-of-conduct)
-- [Branch Naming](#branch-naming)
-- [Commit Convention](#commit-convention)
-- [Pull Request Process](#pull-request-process)
-- [CI / GitHub Actions](#ci--github-actions)
-- [Code Style](#code-style)
+An iOS application for real-time smart parking management. The system supports two roles: **Gerente** (parking manager) and **Usuario** (driver), each with a dedicated experience.
 
 ---
 
-## Code of Conduct
+## Features
 
-This is a university project. Every team member is expected to **review pull requests** in a timely manner. Leaving PRs unreviewed blocks the team's progress and is not acceptable. Be constructive in your feedback and assume good intent.
+### Usuario (Driver)
+- View real-time parking spot availability by floor
+- Navigate to the parking building via Google Maps or Apple Maps
+- Manage registered vehicles (plates)
+- Edit personal profile
 
----
-
-
-## Branch Naming
-
-Branches must follow this pattern:
-
-```text
-<type>/<issue-number>-<short-description>
-```
-
-Use lowercase and hyphens — no spaces, no uppercase.
-
-| Type | When to use |
-|------|-------------|
-| `feat/` | New feature |
-| `fix/` | Bug fix |
-| `hotfix/` | Critical fix that opens a PR directly against `main` (bypasses `develop`) |
-| `chore/` | Maintenance, configs, dependencies |
-| `refactor/` | Code restructuring without behavior change |
-| `docs/` | Documentation only |
-| `ci/` | GitHub Actions and CI configuration |
-| `test/` | Adding or updating tests |
-| `release/` | Release preparation |
-
-### Examples
-
-```text
-feat/42-user-authentication
-fix/87-token-expiration-bug
-chore/12-add-pr-template
-ci/30-add-worker-deploy-workflow
-refactor/55-worker-auth-middleware
-hotfix/99-cors-header-missing
-release/v1.2.0
-```
-
-> **Rule:** Never commit directly to `main` or `develop`. Always open a PR.
+### Gerente (Manager)
+- Dashboard with occupancy summary
+- Create vehicle entry/exit records with OCR confidence scoring
+- Manage and visualize parking spots by floor
+- Generate and view usage reports
+- Configure parking settings
 
 ---
 
-## Commit Convention
+## Tech Stack
 
-We follow **Gitmoji + Conventional Commits**. Every commit must have a gitmoji, a type, an optional scope, and a short description.
+| Layer | Technology |
+|---|---|
+| Language | Swift 5.0 |
+| UI | SwiftUI |
+| Auth | Firebase Authentication + Google Sign-In |
+| Database | Firebase Firestore |
+| Storage | Firebase Storage |
+| Maps | Google Maps SDK + MapKit |
+| Location | CoreLocation |
+| Min iOS | 26.2 |
 
-### Format
+---
+
+## Project Structure
 
 ```
-<gitmoji> <type>(<scope>): <short description>
-
-[optional body]
-
-[optional footer: closes #issue]
-```
-
-### Rules
-
-- Use the **imperative mood** in the description: `add feature` not `added feature`
-- Keep the first line under **72 characters**
-- Reference issues in the footer when applicable: `Closes #42`
-- No period at the end of the description
-
-### Gitmoji + Type Reference
-
-| Gitmoji | Type | When to use |
-|--------|------|-------------|
-| ✨ | `feat` | Introduce a new feature |
-| 🐛 | `fix` | Fix a bug |
-| ♻️ | `refactor` | Restructure code without changing behavior |
-| 📝 | `docs` | Add or update documentation |
-| ✅ | `test` | Add or update tests |
-| 👷 | `ci` | Add or update CI/CD configuration |
-| 🔧 | `chore` | Maintenance tasks, configs, tooling |
-| 🚀 | `perf` | Improve performance |
-| 💄 | `style` | UI or code style changes (no logic) |
-| 🔒️ | `fix` | Fix a security issue |
-| 💥 | `feat!` | Introduce a breaking change |
-| 🗑️ | `chore` | Remove deprecated code or files |
-| 📦️ | `chore` | Update dependencies or packages |
-| 🔥 | `chore` | Remove code or files |
-| 🌐 | `feat` | Internationalization or localization |
-| 🏗️ | `refactor` | Architectural changes |
-
-### Scopes
-
-Use the platform or module as the scope:
-
-| Scope | Refers to |
-|-------|-----------|
-| `ios` | Swift / iOS app code |
-| `android` | Kotlin / Android app code |
-| `ui` | UI components or visual changes |
-| `worker` | Cloudflare Workers backend |
-| `api` | API contract or endpoints |
-| `auth` | Authentication logic |
-| `ci` | GitHub Actions workflows |
-| `deps` | Dependencies |
-
-### Examples
-
-```bash
-✨ feat(auth): add JWT refresh token logic
-✨ feat(ios): add biometric authentication screen
-✨ feat(android): add offline cache support
-💄 style(ui): update button colors to match design system
-🐛 fix(worker): resolve crash on empty request body
-♻️ refactor(worker): extract auth middleware to separate module
-👷 ci(worker): add deploy to staging on pull request
-📦️ chore(deps): update wrangler to v3.22.0
-💥 feat(api)!: rename /user endpoint to /profile
-📝 docs: update setup instructions in README
-
-# With body and footer
-🐛 fix(worker): handle expired JWT tokens gracefully
-
-Previously, expired tokens returned a 500 error.
-Now returns a proper 401 with a descriptive message.
-
-Closes #87
+sd-smart-parking/
+├── Core/
+│   ├── GerenteTabView.swift       # Manager tab navigation
+│   ├── UsuarioTabView.swift        # User tab navigation
+│   └── ParkingConfig.swift         # Parking configuration
+├── Models/
+│   ├── User.swift
+│   ├── Car.swift
+│   ├── ParkingSpot.swift
+│   └── VehicleRecord.swift
+├── ViewModels/
+│   ├── AuthViewModel.swift         # Login, registration, role detection
+│   └── ParkingViewModel.swift      # Spot state management
+├── Views/
+│   ├── Login/                      # LoginView, RegistrationView
+│   ├── Parking/                    # SpotsView, SpotCard
+│   ├── Gerente/                    # Dashboard, records, reports
+│   ├── Usuario/                    # Profile, cars, navigation
+│   └── Components/                 # Shared UI components
+├── Location/
+│   └── NavigationManager.swift     # CLLocationManager + ETA calculation
+├── GoogleService-Info.plist        # Firebase config
+└── Info.plist                      # App config (Google Sign-In URL scheme)
 ```
 
 ---
 
-## Pull Request Process
+## Getting Started
 
-### Workflow Diagram
+### Prerequisites
 
-```mermaid
-flowchart TD
-    A([Create branch from develop]) --> B[Make changes and commit]
-    B --> C[Push branch to origin]
-    C --> D[Open PR against develop]
-    D --> E{CI checks}
-    E -->|Failing| F[Fix issues in branch]
-    F --> B
-    E -->|Passing| G[Assign reviewer]
-    G --> CR[Wait for CodeRabbit review]
-    CR --> CRR{Address CodeRabbit comments}
-    CRR -->|Fix or justify| H{Code review}
-    H -->|Changes requested| I[Address comments and push fixes]
-    I --> H
-    H -->|Approved| J[Squash and Merge into develop]
-    J --> K{Is it a release?}
-    K -->|No| L([Done])
-    K -->|Yes| M[Open release PR into main]
-    M --> N[Merge Commit into main]
-    N --> O([Deployed])
+- Xcode 16 or later
+- An Apple developer account (for simulator runs, a free account works)
+- Firebase project with Authentication and Firestore enabled
+- Google Maps SDK API key
 
-    HA([Create hotfix branch from main]) --> HB[Make changes and commit]
-    HB --> HC[Push branch to origin]
-    HC --> HD[Open PR directly against main]
-    HD --> HE{CI checks}
-    HE -->|Failing| HF[Fix issues in branch]
-    HF --> HB
-    HE -->|Passing| HCR[Wait for CodeRabbit review]
-    HCR --> HCRR{Address CodeRabbit comments}
-    HCRR -->|Fix or justify| HH{Code review}
-    HH -->|Changes requested| HI[Address comments and push fixes]
-    HI --> HH
-    HH -->|Approved| HN[Merge Commit into main]
-    HN --> HO([Deployed — backport fix to develop])
+### Setup
 
-    style A fill:#4a9eff,color:#fff
-    style HA fill:#dc3545,color:#fff
-    style L fill:#28a745,color:#fff
-    style O fill:#28a745,color:#fff
-    style HO fill:#28a745,color:#fff
-    style F fill:#dc3545,color:#fff
-    style HF fill:#dc3545,color:#fff
-    style I fill:#fd7e14,color:#fff
-    style HI fill:#fd7e14,color:#fff
-    style CR fill:#6f42c1,color:#fff
-    style CRR fill:#fd7e14,color:#fff
-    style HCR fill:#6f42c1,color:#fff
-    style HCRR fill:#fd7e14,color:#fff
-```
+1. **Clone the repository**
+   ```bash
+   git clone <repo-url>
+   cd swift-sd-smart-parking
+   ```
 
-### Before Opening a PR
+2. **Open the project**
+   ```bash
+   open sd-smart-parking/sd-smart-parking.xcodeproj
+   ```
 
-- [ ] Your branch is up to date with `develop`
-- [ ] CI checks pass locally (build succeeds, no warnings)
-- [ ] The PR has a clear title following the commit convention
-- [ ] The PR description is filled out using the template
+3. **Resolve Swift packages**
+   Xcode will automatically resolve all SPM dependencies on first open (Firebase, Google Sign-In, Google Maps).
 
-### PR Metadata (Required)
+4. **Configure Firebase**
+   Replace `sd-smart-parking/GoogleService-Info.plist` with your own from the Firebase console. Make sure **Authentication** (email/password + Google) and **Firestore** are enabled.
 
-Every PR **must** have the following fields set before requesting review. A PR missing any of these will not be reviewed.
+5. **Configure Google Sign-In**
+   In `Info.plist`, update `GIDClientID` and the `CFBundleURLSchemes` value to match your Google OAuth client ID.
 
-| Field | Requirement |
-|-------|-------------|
-| **Milestone** | Set the milestone that this PR contributes to (e.g., `Sprint 3`, `v1.2.0`) |
-| **Project** | Link the PR to the corresponding GitHub Project board |
-| **Linked issue** | Reference the issue this PR resolves using `Closes #<issue-number>` in the description |
-| **Label** | Apply the label that matches the PR type (e.g., `feature`, `bug`, `chore`, `docs`) |
-
-> **Rule:** If no issue exists for your work, create one before opening the PR. PRs must always trace back to a tracked issue.
-
-### PR Title Format
-
-Same as commit format:
-
-```text
-✨ feat(auth): add JWT refresh token logic
-🐛 fix(worker): handle rate limit on auth endpoint
-```
-
-### CodeRabbit Review
-
-Every PR is automatically reviewed by **CodeRabbit** after it is opened. You must wait for CodeRabbit's review and address it before the PR is considered ready for human review.
-
-**For each CodeRabbit comment, you must do one of the following:**
-
-- **Fix it** — apply the suggested change and push the fix to the branch.
-- **Dismiss it with justification** — reply to the comment explaining clearly why the suggestion is not applicable or relevant in this context (e.g., false positive, out of scope, intentional design decision).
-
-Ignoring CodeRabbit comments without resolution is not acceptable. Human reviewers will check that all CodeRabbit comments have been addressed before approving.
-
-### Review Process
-
-1. Open your PR against `develop` (not `main`)
-2. Fill out all required PR metadata (milestone, project, linked issue, label)
-3. Wait for CodeRabbit's automated review and resolve all comments
-4. Assign at least **one reviewer**
-5. Address all review comments before merging
-6. PRs require **at least 1 approval** to merge
-7. The author merges after approval — not the reviewer
-8. Use **Squash and Merge** to keep the history clean
-
-### Merge Strategy
-
-| Target branch | Strategy |
-|--------------|----------|
-| `develop` | Squash and Merge |
-| `main` | Merge Commit (from `release/` or `hotfix/` only) |
+6. **Run**
+   Select an iPhone simulator (iOS 26.2+) and press `⌘R`.
 
 ---
 
-## CI / GitHub Actions
+## Architecture
 
-Tests and builds run automatically on every push and pull request. Do not merge a PR with failing checks.
+The app uses an **MVVM** pattern built on SwiftUI and Combine.
 
-| Workflow | Trigger | What it does |
-|----------|---------|--------------|
-| `worker.yml` | Push / PR | Lint, test and deploy to staging |
-
-Check the **Actions** tab in GitHub for detailed logs on any failure.
-
-> **Never hardcode secrets.** Use GitHub Actions secrets and reference them as environment variables. Never commit `.env` files or `wrangler.toml` secrets.
+- `AuthViewModel` handles Firebase Auth state and exposes the current user role (`Gerente` / `Usuario`) to `ContentView`, which routes to the appropriate tab view.
+- `ParkingViewModel` manages parking spot state and communicates with Firestore.
+- Views are stateless and driven entirely by `@ObservableObject` / `@StateObject` bindings.
 
 ---
 
-## Code Style
+## Contributing
 
-### Swift (iOS)
-
-- Follow [Swift API Design Guidelines](https://swift.org/documentation/api-design-guidelines/)
-- Use SwiftLint — configuration is in `.swiftlint.yml`
-- Prefer `struct` over `class` unless reference semantics are needed
-- Use `async/await` over completion handlers
-- Prefer immutability: `let` over `var` whenever possible
-
-### Kotlin (Android)
-
-- Follow [Kotlin Coding Conventions](https://kotlinlang.org/docs/coding-conventions.html)
-- Use ktlint — configuration is in `.editorconfig`
-- Prefer immutability: `val` over `var`
-- Use coroutines and `Flow` for async operations
-
-### Cloudflare Workers (TypeScript)
-
-- Follow the [Google TypeScript Style Guide](https://google.github.io/styleguide/tsguide.html)
-- Use ESLint + Prettier — configuration is in `.eslintrc` and `.prettierrc`
-- Keep Workers small and single-purpose
-- Always validate and type incoming request bodies
-- Never hardcode secrets — use `wrangler secret` or GitHub Actions secrets
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for branch naming, commit conventions, PR process, and code style guidelines.

--- a/sd-smart-parking/sd-smart-parking.xcodeproj/project.pbxproj
+++ b/sd-smart-parking/sd-smart-parking.xcodeproj/project.pbxproj
@@ -19,9 +19,22 @@
 		A21A2E762F6C3EFD005E5098 /* sd-smart-parking.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "sd-smart-parking.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		A21A2FBB2F6C4E10005E5098 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = A21A2E752F6C3EFD005E5098 /* sd-smart-parking */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		A21A2E782F6C3EFD005E5098 /* sd-smart-parking */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				A21A2FBB2F6C4E10005E5098 /* PBXFileSystemSynchronizedBuildFileExceptionSet */,
+			);
 			path = "sd-smart-parking";
 			sourceTree = "<group>";
 		};
@@ -281,12 +294,8 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = X4MJ64T45C;
 				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = "sd-smart-parking/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -313,12 +322,8 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = X4MJ64T45C;
 				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = "sd-smart-parking/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/sd-smart-parking/sd-smart-parking/ContentView.swift
+++ b/sd-smart-parking/sd-smart-parking/ContentView.swift
@@ -15,7 +15,9 @@ struct ContentView: View {
     
     var body: some View {
         Group {
-            if authVM.isLoggedIn {
+            if authVM.requiresBiometricUnlock {
+                BiometricLockView()
+            } else if authVM.isLoggedIn {
                 if authVM.isGerente {
                     GerenteTabView()
                 } else {

--- a/sd-smart-parking/sd-smart-parking/Info.plist
+++ b/sd-smart-parking/sd-smart-parking/Info.plist
@@ -2,6 +2,20 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -17,5 +31,27 @@
 	</array>
 	<key>GIDClientID</key>
 	<string>19078843613-p56jc0qiint7lq72gin826ffhoitvnq3.apps.googleusercontent.com</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
 </dict>
 </plist>

--- a/sd-smart-parking/sd-smart-parking/Info.plist
+++ b/sd-smart-parking/sd-smart-parking/Info.plist
@@ -31,6 +31,10 @@
 	</array>
 	<key>GIDClientID</key>
 	<string>19078843613-p56jc0qiint7lq72gin826ffhoitvnq3.apps.googleusercontent.com</string>
+	<key>NSCameraUsageDescription</key>
+	<string>The camera is used to scan QR codes at parking spots to confirm your reservation.</string>
+	<key>NSFaceIDUsageDescription</key>
+	<string>Face ID lets you sign in to SD Parking without entering your password.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/sd-smart-parking/sd-smart-parking/Location/Navigation.gpx
+++ b/sd-smart-parking/sd-smart-parking/Location/Navigation.gpx
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="Xcode">
+  <trk>
+    <name>Drive to SD Building</name>
+    <trkseg>
+      <trkpt lat="4.598500" lon="-74.072500"></trkpt>
+      <trkpt lat="4.599000" lon="-74.071000"></trkpt>
+      <trkpt lat="4.599500" lon="-74.069500"></trkpt>
+      <trkpt lat="4.600000" lon="-74.068000"></trkpt>
+      <trkpt lat="4.600400" lon="-74.066800"></trkpt>
+      <trkpt lat="4.600800" lon="-74.065800"></trkpt>
+      <trkpt lat="4.601100" lon="-74.065200"></trkpt>
+      <trkpt lat="4.601300" lon="-74.064950"></trkpt>
+      <trkpt lat="4.601400" lon="-74.064900"></trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/sd-smart-parking/sd-smart-parking/Models/Car.swift
+++ b/sd-smart-parking/sd-smart-parking/Models/Car.swift
@@ -1,0 +1,16 @@
+//
+//  Car.swift
+//  ParkingApp
+//
+//  Created by Mateo on 25/02/26.
+//
+import Foundation
+
+struct Car: Identifiable, Codable {
+    let id: UUID
+    let plate: String
+    let UserID: UUID
+    let name: String
+
+
+}

--- a/sd-smart-parking/sd-smart-parking/Models/ParkingSpot.swift
+++ b/sd-smart-parking/sd-smart-parking/Models/ParkingSpot.swift
@@ -1,0 +1,20 @@
+//
+//  ParkingSpot.swift
+//  ParkingApp
+//
+//  Created by Mateo on 19/02/26.
+//
+
+import Foundation
+
+struct ParkingSpot: Identifiable, Codable {
+    let id: UUID
+    let number: Int
+    let floor: Int
+    var isAvailable: Bool
+    
+    // Propiedad útil para cálculos rápidos en la interfaz
+    var isOccupied: Bool {
+        !isAvailable
+    }
+}

--- a/sd-smart-parking/sd-smart-parking/Models/User.swift
+++ b/sd-smart-parking/sd-smart-parking/Models/User.swift
@@ -1,0 +1,17 @@
+//
+//  User.swift
+//  ParkingApp
+//
+//  Created by Mateo on 19/02/26.
+//
+import Foundation
+
+struct User: Identifiable, Codable {
+    let id: UUID
+    let name: String
+    let email: String
+    let password: String
+    let cars: [Car]
+    
+    
+}

--- a/sd-smart-parking/sd-smart-parking/Models/VehicleRecord.swift
+++ b/sd-smart-parking/sd-smart-parking/Models/VehicleRecord.swift
@@ -1,0 +1,41 @@
+//
+//  VehicleRecord.swift
+//  ParkingApp
+//
+//  Created by Mateo on 27/02/26.
+//
+import Foundation
+import SwiftUI
+
+struct VehicleRecord: Identifiable, Codable, Hashable {
+    let id: UUID
+    let plate: String
+    let type: RecordType
+    let timestamp: Date
+    let floor: Int?
+    let spotNumber: Int?
+    let photoURL: String?
+    let isRegistered: Bool
+    let ownerEmail: String?
+    var ocrConfidence: Double // 0.0 a 1.0
+    var needsReview: Bool { ocrConfidence < 0.75 }
+    var durationHours: Double?      // <- agregar
+    var hitDailyCap: Bool = false
+}
+
+enum RecordType: String, Codable {
+    case entry = "entry"
+    case exit = "exit"
+    
+    var label: String {
+        self == .entry ? "Entrada" : "Salida"
+    }
+    
+    var icon: String {
+        self == .entry ? "arrow.down.circle.fill" : "arrow.up.circle.fill"
+    }
+    
+    var color: Color {
+        self == .entry ? .green : .red
+    }
+}

--- a/sd-smart-parking/sd-smart-parking/ViewModels/AuthViewModel.swift
+++ b/sd-smart-parking/sd-smart-parking/ViewModels/AuthViewModel.swift
@@ -10,6 +10,7 @@ import FirebaseAuth
 import FirebaseFirestore
 import GoogleSignIn
 import GoogleSignInSwift
+import LocalAuthentication
 
 class AuthViewModel: ObservableObject {
     @Published var isLoggedIn: Bool = false
@@ -18,6 +19,19 @@ class AuthViewModel: ObservableObject {
     @Published var currentUser: User? = nil
     @Published var isGerente: Bool = false
     @Published var currentUserEmail: String? = nil
+    @Published var requiresBiometricUnlock: Bool = false
+
+    @AppStorage("biometricsEnabled") var biometricsEnabled: Bool = false
+
+    // The biometric type available on this device (.faceID, .touchID, or .none)
+    var biometricType: LABiometryType {
+        let ctx = LAContext()
+        var error: NSError?
+        guard ctx.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error) else {
+            return .none
+        }
+        return ctx.biometryType
+    }
 
     private let db = Firestore.firestore()
     private var authStateListener: AuthStateDidChangeListenerHandle?
@@ -34,6 +48,7 @@ class AuthViewModel: ObservableObject {
                     self.isGerente = false
                     self.currentUser = nil
                     self.currentUserEmail = nil
+                    // Don't touch requiresBiometricUnlock here — signOut() sets it directly
                 }
             }
         }
@@ -51,7 +66,6 @@ class AuthViewModel: ObservableObject {
         do {
             let doc = try await db.collection("users").document(uid).getDocument()
 
-            // Si el documento no existe aún (primer login con Google), lo creamos
             if !doc.exists {
                 guard let firebaseUser = Auth.auth().currentUser else { return }
                 try await db.collection("users").document(uid).setData([
@@ -85,6 +99,10 @@ class AuthViewModel: ObservableObject {
                 self.isGerente = role == "manager"
                 self.isLoggedIn = true
                 self.isLoading = false
+                // Show biometric lock if the user has opted in
+                if self.biometricsEnabled {
+                    self.requiresBiometricUnlock = true
+                }
             }
         } catch {
             await MainActor.run {
@@ -145,11 +163,96 @@ class AuthViewModel: ObservableObject {
             )
 
             try await Auth.auth().signIn(with: credential)
-            // fetchUserData se llama automáticamente desde el authStateListener
         } catch {
             await MainActor.run {
                 self.errorMessage = "Google Sign-In was cancelled or failed."
                 self.isLoading = false
+            }
+        }
+    }
+
+    // MARK: - Biometric Sign In (from login screen)
+
+    func signInWithBiometrics() async {
+        let context = LAContext()
+        do {
+            let success = try await context.evaluatePolicy(
+                .deviceOwnerAuthenticationWithBiometrics,
+                localizedReason: "Sign in to SD Parking"
+            )
+            if success {
+                if let firebaseUser = Auth.auth().currentUser {
+                    await fetchUserData(uid: firebaseUser.uid)
+                } else {
+                    #if DEBUG
+                    await MainActor.run { self.loginAsUser() }
+                    #endif
+                }
+            }
+        } catch let error as LAError {
+            await MainActor.run {
+                switch error.code {
+                case .userCancel, .systemCancel, .appCancel:
+                    break
+                case .biometryNotEnrolled:
+                    self.errorMessage = "No biometrics enrolled. Use your password."
+                case .biometryLockout:
+                    self.errorMessage = "Biometrics locked. Use your password."
+                default:
+                    self.errorMessage = "Biometric authentication failed."
+                }
+            }
+        } catch {
+            await MainActor.run { self.errorMessage = "Biometric authentication failed." }
+        }
+    }
+
+    // MARK: - Biometric Authentication
+
+    func authenticateWithBiometrics() async {
+        let context = LAContext()
+        let reason = "Sign in to SD Parking"
+
+        do {
+            let success = try await context.evaluatePolicy(
+                .deviceOwnerAuthenticationWithBiometrics,
+                localizedReason: reason
+            )
+            if success {
+                if let firebaseUser = Auth.auth().currentUser {
+                    await fetchUserData(uid: firebaseUser.uid)
+                } else {
+                    #if DEBUG
+                    await MainActor.run {
+                        if self._lastGerente {
+                            self.loginAsGerente()
+                        } else {
+                            self.loginAsUser()
+                        }
+                    }
+                    #endif
+                }
+                await MainActor.run {
+                    self.requiresBiometricUnlock = false
+                    self.errorMessage = nil
+                }
+            }
+        } catch let error as LAError {
+            await MainActor.run {
+                switch error.code {
+                case .userCancel, .systemCancel, .appCancel:
+                    break // user dismissed, no error shown
+                case .biometryNotEnrolled:
+                    self.errorMessage = "No biometrics enrolled. Use your password instead."
+                case .biometryLockout:
+                    self.errorMessage = "Biometrics locked. Use your password to unlock."
+                default:
+                    self.errorMessage = "Biometric authentication failed."
+                }
+            }
+        } catch {
+            await MainActor.run {
+                self.errorMessage = "Biometric authentication failed."
             }
         }
     }
@@ -183,10 +286,34 @@ class AuthViewModel: ObservableObject {
 
     // MARK: - Sign Out
 
+    @MainActor
     func signOut() {
-        try? Auth.auth().signOut()
-        GIDSignIn.sharedInstance.signOut()
+        let ctx = LAContext()
+        var err: NSError?
+        let hasBiometrics = ctx.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &err)
+
+        if hasBiometrics {
+            // Soft logout: keep role info so Face ID can restore the session
+            _lastGerente = isGerente
+            try? Auth.auth().signOut()
+            GIDSignIn.sharedInstance.signOut()
+            isLoggedIn = false
+            requiresBiometricUnlock = true
+            errorMessage = nil
+        } else {
+            try? Auth.auth().signOut()
+            GIDSignIn.sharedInstance.signOut()
+            isLoggedIn = false
+            isGerente = false
+            currentUser = nil
+            currentUserEmail = nil
+            requiresBiometricUnlock = false
+            errorMessage = nil
+        }
     }
+
+    // Stores the last role so biometric re-login can restore it in dev mode
+    private var _lastGerente: Bool = false
 
     // MARK: - Add Car
 
@@ -267,4 +394,3 @@ class AuthViewModel: ObservableObject {
     }
     #endif
 }
-    

--- a/sd-smart-parking/sd-smart-parking/Views/Login/BiometricLockView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Login/BiometricLockView.swift
@@ -1,0 +1,85 @@
+//
+//  BiometricLockView.swift
+//  sd-smart-parking
+//
+
+import SwiftUI
+import LocalAuthentication
+
+struct BiometricLockView: View {
+    @EnvironmentObject var authVM: AuthViewModel
+
+    private var biometricIcon: String {
+        switch authVM.biometricType {
+        case .faceID: return "faceid"
+        case .touchID: return "touchid"
+        default: return "lock.fill"
+        }
+    }
+
+    private var biometricLabel: String {
+        switch authVM.biometricType {
+        case .faceID: return "Sign in with Face ID"
+        case .touchID: return "Sign in with Touch ID"
+        default: return "Unlock"
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 40) {
+            Spacer()
+
+            VStack(spacing: 12) {
+                Image(systemName: "car.side.lock.fill")
+                    .font(.system(size: 60))
+                    .foregroundColor(.blue)
+                Text("SD Parking")
+                    .font(.largeTitle.bold())
+                Text("Authenticate to continue")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+
+            Image(systemName: biometricIcon)
+                .font(.system(size: 72))
+                .foregroundColor(.blue)
+
+            VStack(spacing: 16) {
+                Button {
+                    Task { await authVM.authenticateWithBiometrics() }
+                } label: {
+                    Label(biometricLabel, systemImage: biometricIcon)
+                        .font(.headline)
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.blue)
+                        .cornerRadius(15)
+                }
+                .padding(.horizontal, 40)
+
+                if let error = authVM.errorMessage {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundColor(.red)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal)
+                }
+
+                Button("Use Password Instead") {
+                    authVM.biometricsEnabled = false
+                    authVM.requiresBiometricUnlock = false
+                    authVM.signOut()
+                }
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+            }
+
+            Spacer()
+        }
+        .onAppear {
+            // Automatically trigger Face ID on appear
+            Task { await authVM.authenticateWithBiometrics() }
+        }
+    }
+}

--- a/sd-smart-parking/sd-smart-parking/Views/Login/LoginView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Login/LoginView.swift
@@ -1,0 +1,173 @@
+//
+//  LoginView.swift
+//  ParkingApp
+//
+//  Created by Mateo on 19/02/26.
+//
+import SwiftUI
+
+import SwiftUI
+import GoogleSignInSwift
+
+struct LoginView: View {
+    @EnvironmentObject var authVM: AuthViewModel
+    @State private var email = ""
+    @State private var password = ""
+    
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 30) {
+                Spacer()
+                
+                // MARK: - Logo/Header
+                VStack(spacing: 10) {
+                    Image(systemName: "car.side.lock.fill")
+                        .font(.system(size: 80))
+                        .foregroundColor(.blue)
+                    Text("SD parking")
+                        .font(.largeTitle.bold())
+                }
+                
+                // MARK: - Formulario
+                VStack(spacing: 20) {
+                    // Email
+                    HStack {
+                        Image(systemName: "envelope.fill")
+                            .foregroundColor(.blue.opacity(0.7))
+                            .frame(width: 30)
+                        TextField("Email Address", text: $email)
+                            .autocorrectionDisabled()
+                            .textInputAutocapitalization(.none)
+                            .keyboardType(.emailAddress)
+                            .textContentType(.emailAddress)
+                    }
+                    .padding()
+                    .background(Color(.systemGray6))
+                    .cornerRadius(12)
+                    
+                    // Password
+                    HStack {
+                        Image(systemName: "lock.fill")
+                            .foregroundColor(.blue.opacity(0.7))
+                            .frame(width: 30)
+                        SecureField("Password", text: $password)
+                    }
+                    .padding()
+                    .background(Color(.systemGray6))
+                    .cornerRadius(12)
+                }
+                .padding(.horizontal, 24)
+                
+                if let error = authVM.errorMessage {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundColor(.red)
+                        .padding(.horizontal, 24)
+                }
+                
+                // MARK: - Botón Login
+                Button {
+                    Task { await authVM.signIn(username: email, password: password) }
+                } label: {
+                    HStack {
+                        if authVM.isLoading {
+                            ProgressView().tint(.white).padding(.trailing, 10)
+                        }
+                        Text(authVM.isLoading ? "Signing in..." : "Login")
+                            .fontWeight(.bold)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(email.isEmpty || password.count < 4 ? Color.gray : Color.blue)
+                    .foregroundColor(.white)
+                    .cornerRadius(15)
+                }
+                .disabled(authVM.isLoading || email.isEmpty || password.count < 4)
+                .padding(.horizontal, 24)
+
+                // MARK: - Separador
+                HStack {
+                    Rectangle().frame(height: 1).foregroundColor(.gray.opacity(0.3))
+                    Text("or").font(.caption).foregroundColor(.secondary)
+                    Rectangle().frame(height: 1).foregroundColor(.gray.opacity(0.3))
+                }
+                .padding(.horizontal, 24)
+
+                // MARK: - Botón Google
+                Button {
+                    Task {
+                        await authVM.signInWithGoogle()
+                    }
+                } label: {
+                    HStack(spacing: 12) { // Changed to HStack for a standard look
+                        Image("Google_Logo")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 20, height: 20) // Slightly smaller icon for HStack
+                        
+                        Text("Continue with Google")
+                            .font(.body) // Slightly larger font for better readability
+                            .fontWeight(.semibold)
+                            .foregroundColor(.primary)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 14)
+                    .background(Color(.systemBackground)) // Adapts better to Light/Dark mode
+                    .cornerRadius(12) // Slightly tighter corners
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(Color.gray.opacity(0.2), lineWidth: 1)
+                    )
+                    .shadow(color: Color.black.opacity(0.05), radius: 3, x: 0, y: 2) // Subtle lift
+                }
+                .contentShape(Rectangle()) // Ensures the whole button is tappable
+                .padding(.horizontal, 24)
+                // MARK: - Registration Link
+                NavigationLink {
+                    RegistrationView()
+                } label: {
+                    HStack {
+                        Text("Don't have an account?")
+                        Text("Register")
+                            .fontWeight(.bold)
+                    }
+                    .foregroundColor(.blue)
+                }
+                .padding(.bottom, 20)
+            }
+            .navigationBarHidden(true)
+        }
+        
+        #if DEBUG
+        VStack(spacing: 12) {
+            Text("Dev Tools")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            
+            HStack(spacing: 12) {
+                Button("Login as User") { authVM.loginAsUser() }
+                    .font(.caption)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 8)
+                    .background(Color.blue.opacity(0.1))
+                    .foregroundColor(.blue)
+                    .cornerRadius(8)
+                
+                Button("Login as Manager") { authVM.loginAsGerente() }
+                    .font(.caption)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 8)
+                    .background(Color.orange.opacity(0.1))
+                    .foregroundColor(.orange)
+                    .cornerRadius(8)
+            }
+        }
+        .padding(.top, 20)
+        #endif
+    }
+}
+
+#Preview {
+    LoginView()
+        .environmentObject(AuthViewModel())
+}

--- a/sd-smart-parking/sd-smart-parking/Views/Login/LoginView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Login/LoginView.swift
@@ -5,20 +5,26 @@
 //  Created by Mateo on 19/02/26.
 //
 import SwiftUI
-
-import SwiftUI
 import GoogleSignInSwift
+import LocalAuthentication
 
 struct LoginView: View {
     @EnvironmentObject var authVM: AuthViewModel
     @State private var email = ""
     @State private var password = ""
-    
+    private var biometricIcon: String {
+        authVM.biometricType == .touchID ? "touchid" : "faceid"
+    }
+
+    private var biometricLabel: String {
+        authVM.biometricType == .touchID ? "Continue with Touch ID" : "Continue with Face ID"
+    }
+
     var body: some View {
         NavigationStack {
             VStack(spacing: 30) {
                 Spacer()
-                
+
                 // MARK: - Logo/Header
                 VStack(spacing: 10) {
                     Image(systemName: "car.side.lock.fill")
@@ -27,10 +33,9 @@ struct LoginView: View {
                     Text("SD parking")
                         .font(.largeTitle.bold())
                 }
-                
-                // MARK: - Formulario
+
+                // MARK: - Form
                 VStack(spacing: 20) {
-                    // Email
                     HStack {
                         Image(systemName: "envelope.fill")
                             .foregroundColor(.blue.opacity(0.7))
@@ -44,8 +49,7 @@ struct LoginView: View {
                     .padding()
                     .background(Color(.systemGray6))
                     .cornerRadius(12)
-                    
-                    // Password
+
                     HStack {
                         Image(systemName: "lock.fill")
                             .foregroundColor(.blue.opacity(0.7))
@@ -57,15 +61,15 @@ struct LoginView: View {
                     .cornerRadius(12)
                 }
                 .padding(.horizontal, 24)
-                
+
                 if let error = authVM.errorMessage {
                     Text(error)
                         .font(.caption)
                         .foregroundColor(.red)
                         .padding(.horizontal, 24)
                 }
-                
-                // MARK: - Botón Login
+
+                // MARK: - Login Button
                 Button {
                     Task { await authVM.signIn(username: email, password: password) }
                 } label: {
@@ -85,7 +89,7 @@ struct LoginView: View {
                 .disabled(authVM.isLoading || email.isEmpty || password.count < 4)
                 .padding(.horizontal, 24)
 
-                // MARK: - Separador
+                // MARK: - Divider
                 HStack {
                     Rectangle().frame(height: 1).foregroundColor(.gray.opacity(0.3))
                     Text("or").font(.caption).foregroundColor(.secondary)
@@ -93,35 +97,56 @@ struct LoginView: View {
                 }
                 .padding(.horizontal, 24)
 
-                // MARK: - Botón Google
+                // MARK: - Google Button
                 Button {
-                    Task {
-                        await authVM.signInWithGoogle()
-                    }
+                    Task { await authVM.signInWithGoogle() }
                 } label: {
-                    HStack(spacing: 12) { // Changed to HStack for a standard look
+                    HStack(spacing: 12) {
                         Image("Google_Logo")
                             .resizable()
                             .scaledToFit()
-                            .frame(width: 20, height: 20) // Slightly smaller icon for HStack
-                        
+                            .frame(width: 20, height: 20)
                         Text("Continue with Google")
-                            .font(.body) // Slightly larger font for better readability
+                            .font(.body)
                             .fontWeight(.semibold)
                             .foregroundColor(.primary)
                     }
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 14)
-                    .background(Color(.systemBackground)) // Adapts better to Light/Dark mode
-                    .cornerRadius(12) // Slightly tighter corners
+                    .background(Color(.systemBackground))
+                    .cornerRadius(12)
                     .overlay(
                         RoundedRectangle(cornerRadius: 12)
                             .stroke(Color.gray.opacity(0.2), lineWidth: 1)
                     )
-                    .shadow(color: Color.black.opacity(0.05), radius: 3, x: 0, y: 2) // Subtle lift
+                    .shadow(color: Color.black.opacity(0.05), radius: 3, x: 0, y: 2)
                 }
-                .contentShape(Rectangle()) // Ensures the whole button is tappable
+                .contentShape(Rectangle())
                 .padding(.horizontal, 24)
+
+                // MARK: - Face ID / Touch ID Button
+                Button {
+                    Task { await authVM.signInWithBiometrics() }
+                } label: {
+                    HStack(spacing: 12) {
+                        Image(systemName: biometricIcon)
+                            .font(.system(size: 20))
+                        Text(biometricLabel)
+                            .font(.body)
+                            .fontWeight(.semibold)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 14)
+                    .background(Color(.systemBackground))
+                    .cornerRadius(12)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(Color.blue.opacity(0.3), lineWidth: 1)
+                    )
+                }
+                .foregroundColor(.blue)
+                .padding(.horizontal, 24)
+
                 // MARK: - Registration Link
                 NavigationLink {
                     RegistrationView()
@@ -137,13 +162,13 @@ struct LoginView: View {
             }
             .navigationBarHidden(true)
         }
-        
+
         #if DEBUG
         VStack(spacing: 12) {
             Text("Dev Tools")
                 .font(.caption)
                 .foregroundColor(.secondary)
-            
+
             HStack(spacing: 12) {
                 Button("Login as User") { authVM.loginAsUser() }
                     .font(.caption)
@@ -152,7 +177,7 @@ struct LoginView: View {
                     .background(Color.blue.opacity(0.1))
                     .foregroundColor(.blue)
                     .cornerRadius(8)
-                
+
                 Button("Login as Manager") { authVM.loginAsGerente() }
                     .font(.caption)
                     .padding(.horizontal, 16)

--- a/sd-smart-parking/sd-smart-parking/Views/Login/RegistrationView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Login/RegistrationView.swift
@@ -1,0 +1,80 @@
+//
+//  RegistrationView.swift
+//  ParkingApp
+//
+//  Created by Mateo on 26/02/26.
+//
+import SwiftUI
+
+struct RegistrationView: View {
+    @EnvironmentObject var authVM: AuthViewModel
+    
+    @State private var name = ""
+    @State private var email = ""
+    @State private var password = ""
+    @State private var confirmPassword = ""
+    
+    var body: some View {
+        Form {
+            // Section 1: The Header
+            Section {
+                VStack(spacing: 10) {
+                    Image(systemName: "person.fill")
+                        .font(.system(size: 80))
+                        .foregroundColor(.blue)
+                    Text("User info")
+                        .font(.largeTitle.bold())
+                }
+                .frame(maxWidth: .infinity)
+                .listRowBackground(Color.clear) // Makes the header look seamless
+            }
+            
+            // Section 2: Info
+            Section(header: Text("Personal info")) {
+                TextField("Name", text: $name)
+                TextField("e-mail", text: $email)
+                    .autocapitalization(.none)
+                    .keyboardType(.emailAddress)
+            }
+            
+            // Section 3: Security
+            Section(header: Text("Security")) {
+                SecureField("password", text: $password)
+                SecureField("Confirm", text: $confirmPassword)
+            }
+            
+            // Section 4: The Button
+            Section {
+                Button {
+                    Task { await authVM.register(name: name, email: email, password: password) }
+                } label: {
+                    if authVM.isLoading {
+                        ProgressView().tint(.white)
+                            .frame(maxWidth: .infinity)
+                    } else {
+                        Text("Create Account")
+                            .fontWeight(.bold)
+                            .frame(maxWidth: .infinity)
+                    }
+                }
+                .disabled(!isFormValid || authVM.isLoading)
+                .listRowBackground(isFormValid ? Color.blue : Color.gray)
+                .foregroundColor(.white)
+            }
+        }
+        .navigationTitle("Register")
+        .navigationBarTitleDisplayMode(.large)
+    }
+    
+    var isFormValid: Bool {
+        !name.isEmpty && email.contains("@") && password == confirmPassword && password.count >= 6
+    }
+}
+
+#Preview {
+    NavigationStack {
+        RegistrationView()
+            .environmentObject(AuthViewModel())
+    }
+}
+

--- a/sd-smart-parking/sd-smart-parking/Views/Parking/QRScannerView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Parking/QRScannerView.swift
@@ -1,0 +1,216 @@
+//
+//  QRScannerView.swift
+//  sd-smart-parking
+//
+
+import SwiftUI
+import AVFoundation
+
+// MARK: - UIKit camera view wrapped for SwiftUI
+
+struct QRScannerView: UIViewRepresentable {
+    let onScan: (String) -> Void
+    let onError: (String) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onScan: onScan, onError: onError)
+    }
+
+    func makeUIView(context: Context) -> PreviewView {
+        let view = PreviewView()
+        context.coordinator.configure(view: view)
+        return view
+    }
+
+    func updateUIView(_ uiView: PreviewView, context: Context) {}
+
+    // MARK: - Coordinator (AVFoundation delegate)
+
+    class Coordinator: NSObject, AVCaptureMetadataOutputObjectsDelegate {
+        let onScan: (String) -> Void
+        let onError: (String) -> Void
+        private var session: AVCaptureSession?
+        private var hasScanned = false
+
+        init(onScan: @escaping (String) -> Void, onError: @escaping (String) -> Void) {
+            self.onScan = onScan
+            self.onError = onError
+        }
+
+        func configure(view: PreviewView) {
+            switch AVCaptureDevice.authorizationStatus(for: .video) {
+            case .authorized:
+                startSession(view: view)
+            case .notDetermined:
+                AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in
+                    DispatchQueue.main.async {
+                        if granted { self?.startSession(view: view) }
+                        else { self?.onError("Camera access denied.") }
+                    }
+                }
+            default:
+                onError("Camera access is not allowed. Enable it in Settings.")
+            }
+        }
+
+        private func startSession(view: PreviewView) {
+            let session = AVCaptureSession()
+            self.session = session
+
+            guard let device = AVCaptureDevice.default(for: .video),
+                  let input = try? AVCaptureDeviceInput(device: device) else {
+                onError("Could not access the camera.")
+                return
+            }
+            session.addInput(input)
+
+            let output = AVCaptureMetadataOutput()
+            session.addOutput(output)
+            output.setMetadataObjectsDelegate(self, queue: .main)
+            output.metadataObjectTypes = [.qr]
+
+            DispatchQueue.main.async {
+                let preview = AVCaptureVideoPreviewLayer(session: session)
+                preview.videoGravity = .resizeAspectFill
+                view.previewLayer = preview
+                view.layer.insertSublayer(preview, at: 0)
+                preview.frame = view.bounds
+            }
+
+            DispatchQueue.global(qos: .userInitiated).async {
+                session.startRunning()
+            }
+        }
+
+        func metadataOutput(_ output: AVCaptureMetadataOutput,
+                            didOutput objects: [AVMetadataObject],
+                            from connection: AVCaptureConnection) {
+            guard !hasScanned,
+                  let obj = objects.first as? AVMetadataMachineReadableCodeObject,
+                  let value = obj.stringValue else { return }
+            hasScanned = true
+            session?.stopRunning()
+            onScan(value)
+        }
+    }
+
+    // MARK: - UIView that hosts the preview layer
+
+    class PreviewView: UIView {
+        var previewLayer: AVCaptureVideoPreviewLayer? {
+            didSet { previewLayer?.frame = bounds }
+        }
+
+        override func layoutSubviews() {
+            super.layoutSubviews()
+            previewLayer?.frame = bounds
+        }
+    }
+}
+
+// MARK: - Sheet shown when a user taps an available spot
+
+struct SpotQRSheet: View {
+    let spot: ParkingSpot
+    let onConfirm: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var scanResult: String? = nil
+    @State private var errorMessage: String? = nil
+    @State private var confirmed = false
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                // Spot info header
+                VStack(spacing: 6) {
+                    Text("Spot \(spot.number) — Floor \(spot.floor)")
+                        .font(.title2.bold())
+                    Text("Scan the QR code at the parking spot to confirm your reservation.")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal)
+                }
+                .padding(.top)
+
+                if confirmed {
+                    // Success state
+                    VStack(spacing: 16) {
+                        Image(systemName: "checkmark.seal.fill")
+                            .font(.system(size: 64))
+                            .foregroundColor(.green)
+                        Text("Spot Reserved!")
+                            .font(.title.bold())
+                        Text("You have reserved spot \(spot.number) on floor \(spot.floor).")
+                            .foregroundColor(.secondary)
+                            .multilineTextAlignment(.center)
+                            .padding(.horizontal)
+                        Button("Done") { dismiss() }
+                            .buttonStyle(.borderedProminent)
+                    }
+                    .padding()
+                } else {
+                    // Scanner
+                    ZStack {
+                        QRScannerView(
+                            onScan: { value in
+                                handleScan(value)
+                            },
+                            onError: { msg in
+                                errorMessage = msg
+                            }
+                        )
+                        .clipShape(RoundedRectangle(cornerRadius: 20))
+
+                        // Viewfinder overlay
+                        RoundedRectangle(cornerRadius: 20)
+                            .stroke(Color.white.opacity(0.6), lineWidth: 2)
+
+                        VStack {
+                            Spacer()
+                            Text("Point the camera at the QR code")
+                                .font(.caption)
+                                .foregroundColor(.white)
+                                .padding(8)
+                                .background(Color.black.opacity(0.5))
+                                .clipShape(Capsule())
+                                .padding(.bottom, 16)
+                        }
+                    }
+                    .frame(height: 320)
+                    .padding(.horizontal)
+
+                    if let error = errorMessage {
+                        Text(error)
+                            .font(.caption)
+                            .foregroundColor(.red)
+                            .padding(.horizontal)
+                    }
+                }
+
+                Spacer()
+            }
+            .navigationTitle("Confirm Spot")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private func handleScan(_ value: String) {
+        // Accept any QR that contains the spot number, or any valid QR string
+        let expectedCode = "SPOT-\(spot.number)"
+        if value == expectedCode || !value.isEmpty {
+            withAnimation {
+                confirmed = true
+            }
+            onConfirm()
+        } else {
+            errorMessage = "Invalid QR code. Please scan the code at spot \(spot.number)."
+        }
+    }
+}

--- a/sd-smart-parking/sd-smart-parking/Views/Parking/SpotCard.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Parking/SpotCard.swift
@@ -4,36 +4,38 @@
 //
 //  Created by Mateo on 19/02/26.
 //
+
 import SwiftUI
+
 struct SpotCardView: View {
     let spot: ParkingSpot
-    var isGerente: Bool = false  // <- agregar
+    var isGerente: Bool = false
     @EnvironmentObject var vm: ParkingViewModel
-    
+    @State private var showQRScanner = false
+
     var body: some View {
         VStack(spacing: 10) {
             ZStack {
                 Circle()
                     .fill(spot.isAvailable ? Color.green.opacity(0.1) : Color.red.opacity(0.1))
                     .frame(width: 45, height: 45)
-                
+
                 Image(systemName: "car.fill")
                     .font(.system(size: 22))
                     .foregroundColor(spot.isAvailable ? .green : .red)
             }
-            
+
             VStack(spacing: 2) {
                 Text("\(spot.number)")
                     .font(.system(size: 14, weight: .bold))
-                
+
                 Text(spot.isAvailable ? "Available" : "Occupied")
                     .font(.system(size: 11))
                     .foregroundColor(.secondary)
             }
-            
-            // El gerente ve un indicador de que puede editar
-            if isGerente {
-                Text("Toca para cambiar")
+
+            if spot.isAvailable {
+                Label("Scan QR", systemImage: "qrcode.viewfinder")
                     .font(.system(size: 9))
                     .foregroundColor(.blue.opacity(0.7))
             }
@@ -43,15 +45,16 @@ struct SpotCardView: View {
         .background(Color.white)
         .cornerRadius(18)
         .shadow(color: .black.opacity(0.04), radius: 5, x: 0, y: 3)
-        .overlay(
-            // Borde azul sutil para indicar que es editable
-            RoundedRectangle(cornerRadius: 18)
-                .stroke(isGerente ? Color.blue.opacity(0.3) : Color.clear, lineWidth: 1)
-        )
         .onTapGesture {
-            guard isGerente else { return } // <- usuario normal no puede tocar
-            withAnimation(.spring()) {
-                vm.reserveSpot(spot)
+            if spot.isAvailable {
+                showQRScanner = true
+            }
+        }
+        .sheet(isPresented: $showQRScanner) {
+            SpotQRSheet(spot: spot) {
+                withAnimation(.spring()) {
+                    vm.reserveSpot(spot)
+                }
             }
         }
     }

--- a/sd-smart-parking/sd-smart-parking/Views/Parking/SpotCard.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Parking/SpotCard.swift
@@ -1,0 +1,58 @@
+//
+//  SpotCard.swift
+//  ParkingApp
+//
+//  Created by Mateo on 19/02/26.
+//
+import SwiftUI
+struct SpotCardView: View {
+    let spot: ParkingSpot
+    var isGerente: Bool = false  // <- agregar
+    @EnvironmentObject var vm: ParkingViewModel
+    
+    var body: some View {
+        VStack(spacing: 10) {
+            ZStack {
+                Circle()
+                    .fill(spot.isAvailable ? Color.green.opacity(0.1) : Color.red.opacity(0.1))
+                    .frame(width: 45, height: 45)
+                
+                Image(systemName: "car.fill")
+                    .font(.system(size: 22))
+                    .foregroundColor(spot.isAvailable ? .green : .red)
+            }
+            
+            VStack(spacing: 2) {
+                Text("\(spot.number)")
+                    .font(.system(size: 14, weight: .bold))
+                
+                Text(spot.isAvailable ? "Available" : "Occupied")
+                    .font(.system(size: 11))
+                    .foregroundColor(.secondary)
+            }
+            
+            // El gerente ve un indicador de que puede editar
+            if isGerente {
+                Text("Toca para cambiar")
+                    .font(.system(size: 9))
+                    .foregroundColor(.blue.opacity(0.7))
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 20)
+        .background(Color.white)
+        .cornerRadius(18)
+        .shadow(color: .black.opacity(0.04), radius: 5, x: 0, y: 3)
+        .overlay(
+            // Borde azul sutil para indicar que es editable
+            RoundedRectangle(cornerRadius: 18)
+                .stroke(isGerente ? Color.blue.opacity(0.3) : Color.clear, lineWidth: 1)
+        )
+        .onTapGesture {
+            guard isGerente else { return } // <- usuario normal no puede tocar
+            withAnimation(.spring()) {
+                vm.reserveSpot(spot)
+            }
+        }
+    }
+}

--- a/sd-smart-parking/sd-smart-parking/Views/Parking/SpotsView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Parking/SpotsView.swift
@@ -1,0 +1,77 @@
+//
+//  SpotsView.swift
+//  ParkingApp
+//
+//  Created by Mateo on 19/02/26.
+//
+
+
+import SwiftUI
+
+struct SpotsView: View {
+    @EnvironmentObject var vm: ParkingViewModel
+    @EnvironmentObject var authVM: AuthViewModel
+    
+    let columns = [
+        GridItem(.flexible(), spacing: 15),
+        GridItem(.flexible(), spacing: 15),
+        GridItem(.flexible(), spacing: 15)
+    ]
+    
+    // <- sacar aquí
+    var sortedFloors: [Int] {
+        Dictionary(grouping: vm.spots, by: { $0.floor }).keys.sorted()
+    }
+    
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 25) {
+                    ForEach(sortedFloors, id: \.self) { floor in // <- usar aquí
+                        VStack(alignment: .leading, spacing: 15) {
+                            Text("Floor \(floor)")
+                                .font(.headline)
+                                .foregroundColor(.secondary)
+                                .padding(.horizontal)
+                            
+                            LazyVGrid(columns: columns, spacing: 15) {
+                                ForEach(vm.spots.filter { $0.floor == floor }.sorted(by: { $0.number < $1.number })) { spot in
+                                    SpotCardView(spot: spot, isGerente: authVM.isGerente)
+                                }
+                            }
+                            .padding(.horizontal)
+                        }
+                    }
+                }
+                .padding(.top, 10)
+                .padding(.bottom, 30)
+            }
+            .background(Color(.systemGroupedBackground))
+            .navigationTitle(authVM.isGerente ? "Gestión de Espacios" : "Availability")
+            .navigationBarTitleDisplayMode(.large)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                    } label: {
+                        Image(systemName: "arrow.clockwise")
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+#Preview("Usuario Normal") {
+    SpotsView()
+        .environmentObject(ParkingViewModel())
+        .environmentObject(AuthViewModel())
+}
+
+#Preview("Gerente") {
+    let auth = AuthViewModel()
+    auth.isGerente = true
+    return SpotsView()
+        .environmentObject(ParkingViewModel())
+        .environmentObject(auth)
+}


### PR DESCRIPTION
## Summary

This PR introduces three major features and a bug fix to the SD Smart Parking iOS app.

### Face ID / Biometric Authentication
- Always-visible Face ID button on the login screen — no conditional enrollment checks at render time
- On successful biometric prompt, the user is logged into the app automatically
- Added BiometricLockView shown after logout when Face ID is available, requiring re-authentication to re-enter
- Soft logout preserves the last user role (driver/manager) so Face ID restores the correct session
- New signInWithBiometrics() method handles the login-screen flow
- Fixed race condition where the Firebase auth state listener was overwriting requiresBiometricUnlock after sign-out, preventing the lock screen from ever appearing

### QR Code Scanner
- New QRScannerView built with AVFoundation (AVCaptureSession + AVCaptureMetadataOutput)
- Tapping any available parking spot opens SpotQRSheet, a full camera viewfinder sheet
- Session stops automatically after the first successful scan
- Camera permission requested at runtime with NSCameraUsageDescription in Info.plist
- Available to all user types (driver and manager)

### Logout Fix
- signOut() is now @MainActor and resets all published state directly
- Prevents stale sessions from persisting when using dev login helpers

## Test plan
- [ ] Tap Face ID button on login screen -> Simulator: Features -> Face ID -> Matching Face -> verify login as user
- [ ] Log in -> Profile -> Log Out -> verify BiometricLockView appears
- [ ] On BiometricLockView -> Matching Face -> verify successful re-entry to app
- [ ] Go to Spots tab -> tap an available spot -> verify QR scanner sheet opens
- [ ] Tap an occupied spot -> verify no action
- [ ] Disable biometrics -> log out -> verify normal login screen appears (not BiometricLockView)