### PR TITLE
feat: spot sync, admin spot controls, and weather overlay

### DIFF
--- a/sd-smart-parking/sd-smart-parking/ViewModels/ParkingViewModel.swift
+++ b/sd-smart-parking/sd-smart-parking/ViewModels/ParkingViewModel.swift
@@ -122,11 +122,14 @@ class ParkingViewModel: ObservableObject {
             if let recordId = record.id {
                 db.collection("vehicleRecords").document(recordId).setData(data)
             } else {
-                // Si es un registro nuevo sin ID, dejamos que Firestore cree uno
                 db.collection("vehicleRecords").addDocument(data: data)
             }
+            // Mark spot as occupied when an entry is registered with location
+            if let floor = record.floor, let spotNumber = record.spotNumber {
+                Task { await updateSpotAvailability(floor: floor, spotNumber: spotNumber, available: false) }
             }
         }
+    }
     
  
     // MARK: - Calculate exit fee
@@ -154,11 +157,34 @@ class ParkingViewModel: ObservableObject {
             try await db.collection("vehicleRecords").addDocument(data: data)
             print("✅ Salida única registrada.")
 
+            // 4. Free the spot when exit is registered
+            if let floor = record.floor, let spotNumber = record.spotNumber {
+                await updateSpotAvailability(floor: floor, spotNumber: spotNumber, available: true)
+            }
+
         } catch {
             print("Error en validación de salida: \(error.localizedDescription)")
         }
     }
-    
+
+    // MARK: - Update spot availability by floor and spot number
+
+    func updateSpotAvailability(floor: Int, spotNumber: Int, available: Bool) async {
+        let targetNumber = (floor * 100) + spotNumber
+        do {
+            let snapshot = try await db.collection("parkingSpots")
+                .whereField("floor", isEqualTo: floor)
+                .whereField("number", isEqualTo: targetNumber)
+                .limit(to: 1)
+                .getDocuments()
+            if let ref = snapshot.documents.first?.reference {
+                try await ref.updateData(["isAvailable": available])
+            }
+        } catch {
+            print("Error updating spot availability: \(error.localizedDescription)")
+        }
+    }
+
     // MARK: -- Delete Record
     func deleteRecord(_ record: VehicleRecord) {
         guard let id = record.id else { return }

--- a/sd-smart-parking/sd-smart-parking/ViewModels/WeatherViewModel.swift
+++ b/sd-smart-parking/sd-smart-parking/ViewModels/WeatherViewModel.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+import Combine
+
+struct WeatherData {
+    let temperature: Double
+    let weatherCode: Int
+
+    var symbolName: String {
+        switch weatherCode {
+        case 0, 1:       return "sun.max.fill"
+        case 2:          return "cloud.sun.fill"
+        case 3:          return "cloud.fill"
+        case 45, 48:     return "cloud.fog.fill"
+        case 51, 53, 55: return "cloud.drizzle.fill"
+        case 61, 63, 65: return "cloud.rain.fill"
+        case 71, 73, 75: return "cloud.snow.fill"
+        case 80, 81, 82: return "cloud.heavyrain.fill"
+        case 95, 96, 99: return "cloud.bolt.rain.fill"
+        default:         return "cloud.fill"
+        }
+    }
+
+    var symbolColor: Color {
+        switch weatherCode {
+        case 0, 1:       return .yellow
+        case 2:          return .orange
+        case 3:          return .gray
+        case 45, 48:     return .gray
+        case 51, 53, 55: return .blue
+        case 61, 63, 65: return .blue
+        case 71, 73, 75: return .cyan
+        case 80, 81, 82: return .blue
+        case 95, 96, 99: return .purple
+        default:         return .secondary
+        }
+    }
+}
+
+@MainActor
+class WeatherViewModel: ObservableObject {
+    @Published var weather: WeatherData?
+    @Published var isLoading = false
+
+    // Coordinates of the SD Building parking (Bogotá)
+    private let latitude  = 4.6014
+    private let longitude = -74.0649
+
+    init() {
+        Task { await fetchWeather() }
+    }
+
+    func fetchWeather() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        let urlString = "https://api.open-meteo.com/v1/forecast?latitude=\(latitude)&longitude=\(longitude)&current=temperature_2m,weather_code"
+        guard let url = URL(string: urlString) else { return }
+
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            if let json    = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let current = json["current"] as? [String: Any],
+               let temp    = current["temperature_2m"] as? Double,
+               let code    = current["weather_code"] as? Int {
+                weather = WeatherData(temperature: temp, weatherCode: code)
+            }
+        } catch {
+            print("Weather fetch error: \(error.localizedDescription)")
+        }
+    }
+}

--- a/sd-smart-parking/sd-smart-parking/Views/Parking/SpotCard.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Parking/SpotCard.swift
@@ -34,7 +34,11 @@ struct SpotCardView: View {
                     .foregroundColor(.secondary)
             }
 
-            if spot.isAvailable {
+            if isGerente {
+                Text(spot.isAvailable ? "Tap to occupy" : "Tap to free")
+                    .font(.system(size: 9))
+                    .foregroundColor(spot.isAvailable ? .green.opacity(0.8) : .red.opacity(0.8))
+            } else if spot.isAvailable {
                 Label("Scan QR", systemImage: "qrcode.viewfinder")
                     .font(.system(size: 9))
                     .foregroundColor(.blue.opacity(0.7))
@@ -46,7 +50,11 @@ struct SpotCardView: View {
         .cornerRadius(18)
         .shadow(color: .black.opacity(0.04), radius: 5, x: 0, y: 3)
         .onTapGesture {
-            if spot.isAvailable {
+            if isGerente {
+                withAnimation(.spring()) {
+                    vm.reserveSpot(spot)
+                }
+            } else if spot.isAvailable {
                 showQRScanner = true
             }
         }

--- a/sd-smart-parking/sd-smart-parking/Views/Usuario/Navigation/SDNavigationView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Usuario/Navigation/SDNavigationView.swift
@@ -8,28 +8,52 @@
 import SwiftUI
 
 struct SDNavigationView: View {
-    
-    
+
     @StateObject private var navManager = NavigationManager()
+    @StateObject private var weatherVM  = WeatherViewModel()
     @State private var showNavigation = false
-    
+
     var body: some View {
         NavigationStack {
             VStack(spacing: 16) {
-                
-                // 🔹 LIVE CAPACITY CARD
+
+                // LIVE CAPACITY CARD
                 LiveCapacityCard(available: 40, total: 120, queue: 3)
-                
-                // MAP VIEW WITH INFO OVERLAY
+
+                // MAP VIEW WITH OVERLAYS
                 ZStack(alignment: .bottomTrailing) {
                     AppleMapsView(navManager: navManager)
-                        .frame(maxHeight: .infinity) // ✅ El mapa ocupa el espacio disponible
+                        .frame(maxHeight: .infinity)
                         .clipShape(RoundedRectangle(cornerRadius: 20))
-                    
+
+                    // Weather overlay — top leading
+                    Group {
+                        if let weather = weatherVM.weather {
+                            HStack(spacing: 6) {
+                                Image(systemName: weather.symbolName)
+                                    .foregroundColor(weather.symbolColor)
+                                Text("\(Int(weather.temperature))°C")
+                                    .font(.subheadline.bold())
+                            }
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 8)
+                            .background(.ultraThinMaterial)
+                            .cornerRadius(12)
+                        } else if weatherVM.isLoading {
+                            ProgressView()
+                                .padding(8)
+                                .background(.ultraThinMaterial)
+                                .cornerRadius(12)
+                        }
+                    }
+                    .padding(10)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+
+                    // Route info — bottom trailing
                     VStack(alignment: .trailing, spacing: 6) {
                         Text("Route to SD Building")
                             .font(.caption.bold())
-                        
+
                         HStack(spacing: 16) {
                             Label(navManager.travelTime, systemImage: "clock.fill")
                             Label(navManager.distance, systemImage: "road.lanes")


### PR DESCRIPTION
## Summary

Three bug fixes and one new feature targeting the admin spots view, real-time spot availability sync, and the user navigation map.

## Changes

### 1. Spot sync — `ParkingViewModel.swift`

- Added `updateSpotAvailability(floor:spotNumber:available:)` that queries Firestore for the matching spot by floor + number and updates `isAvailable`
- `addRecord()` now calls it with `available: false` when an entry record with a location is saved
- `calculateAndSaveExit()` now calls it with `available: true` after a valid exit is registered

**Result:** admin adds a car to Floor 1, Spot 3 → Firestore spot document flips to `isAvailable = false` → both admin and user see the spot as occupied in real-time via the existing snapshot listener.

### 2. Admin SpotCard — `SpotCard.swift`

- Admin (`isGerente = true`) can now tap **any** spot (occupied or available) to toggle it directly via `reserveSpot` — no QR scanner shown
- Bottom label now shows `"Tap to occupy"` (green) or `"Tap to free"` (red) for admin
- User behavior is unchanged: available spots open the QR scanner

### 3. Weather overlay — `WeatherViewModel.swift` + `SDNavigationView.swift`

- New `WeatherViewModel` fetches live weather from the free **Open-Meteo API** (no API key needed) using the parking's Bogotá coordinates
- Temperature + SF Symbol (sun/cloud/rain/snow/storm) with correct color displayed as a frosted glass pill in the **top-left corner of the map**
- Shows a `ProgressView` while loading; updates automatically on view appear

## Test plan

- [x] Admin: create a manual entry record for Floor 1, Spot 3 → verify spot card turns red/occupied for both admin and user roles
- [x] Admin: open RecordDetailView and tap "Register Exit" → verify spot turns green/available again
- [x] Admin: tap an available spot card → verify it toggles to occupied (no QR sheet opens)
- [x] Admin: tap an occupied spot card → verify it toggles back to available
- [x] User: open Navigation tab → verify weather pill appears top-left of map with temperature and icon
- [x] User: spot view reflects admin changes in real-time without refresh
