### PR TITLE
✨ feat(parking): add best floor recommendation to spots view

### DIFF
--- a/sd-smart-parking/sd-smart-parking.xcodeproj/project.pbxproj
+++ b/sd-smart-parking/sd-smart-parking.xcodeproj/project.pbxproj
@@ -15,8 +15,19 @@
 		A21A2FBA2F6C4E02005E5098 /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = A21A2FB92F6C4E02005E5098 /* FirebaseStorage */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		F94CDD05428348EBA28D80D0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A21A2E6E2F6C3EFD005E5098 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A21A2E752F6C3EFD005E5098;
+			remoteInfo = "sd-smart-parking";
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		A21A2E762F6C3EFD005E5098 /* sd-smart-parking.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "sd-smart-parking.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FD4A3D2C2F8813D30012A923 /* sd-smart-parkingTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "sd-smart-parkingTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -30,6 +41,11 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		0A0FEDAD77504411A6D9614B /* sd-smart-parkingTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "sd-smart-parkingTests";
+			sourceTree = "<group>";
+		};
 		A21A2E782F6C3EFD005E5098 /* sd-smart-parking */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
@@ -54,6 +70,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C843732C558E4DDD895E643F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -61,6 +84,7 @@
 			isa = PBXGroup;
 			children = (
 				A21A2E782F6C3EFD005E5098 /* sd-smart-parking */,
+				0A0FEDAD77504411A6D9614B /* sd-smart-parkingTests */,
 				A21A2E772F6C3EFD005E5098 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -69,6 +93,7 @@
 			isa = PBXGroup;
 			children = (
 				A21A2E762F6C3EFD005E5098 /* sd-smart-parking.app */,
+				FD4A3D2C2F8813D30012A923 /* sd-smart-parkingTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -76,6 +101,29 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		8BA70FE09BD04F2786A81492 /* sd-smart-parkingTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2F17E05D5733420BB5F80EB8 /* Build configuration list for PBXNativeTarget "sd-smart-parkingTests" */;
+			buildPhases = (
+				932ADF26446D4EC0924D28D1 /* Sources */,
+				C843732C558E4DDD895E643F /* Frameworks */,
+				2DD071DA589D4DCABEF6F7EF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				2455190EC99144CA8B6209EF /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				0A0FEDAD77504411A6D9614B /* sd-smart-parkingTests */,
+			);
+			name = "sd-smart-parkingTests";
+			packageProductDependencies = (
+			);
+			productName = "sd-smart-parkingTests";
+			productReference = FD4A3D2C2F8813D30012A923 /* sd-smart-parkingTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		A21A2E752F6C3EFD005E5098 /* sd-smart-parking */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = A21A2E812F6C3EFE005E5098 /* Build configuration list for PBXNativeTarget "sd-smart-parking" */;
@@ -114,6 +162,10 @@
 				LastSwiftUpdateCheck = 2630;
 				LastUpgradeCheck = 2630;
 				TargetAttributes = {
+					8BA70FE09BD04F2786A81492 = {
+						CreatedOnToolsVersion = 26.3;
+						TestTargetID = A21A2E752F6C3EFD005E5098;
+					};
 					A21A2E752F6C3EFD005E5098 = {
 						CreatedOnToolsVersion = 26.3;
 					};
@@ -139,11 +191,19 @@
 			projectRoot = "";
 			targets = (
 				A21A2E752F6C3EFD005E5098 /* sd-smart-parking */,
+				8BA70FE09BD04F2786A81492 /* sd-smart-parkingTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		2DD071DA589D4DCABEF6F7EF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A21A2E742F6C3EFD005E5098 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -154,6 +214,13 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		932ADF26446D4EC0924D28D1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A21A2E722F6C3EFD005E5098 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -162,6 +229,14 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		2455190EC99144CA8B6209EF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A21A2E752F6C3EFD005E5098 /* sd-smart-parking */;
+			targetProxy = F94CDD05428348EBA28D80D0 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		A21A2E7F2F6C3EFE005E5098 /* Debug */ = {
@@ -292,7 +367,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = X4MJ64T45C;
+				DEVELOPMENT_TEAM = 827AL5HLRB;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "sd-smart-parking/Info.plist";
@@ -302,7 +377,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "appMoviles.sd-smart-parking";
+				PRODUCT_BUNDLE_IDENTIFIER = co.edu.uniandes.dbenavid.sdSmartParking;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
@@ -321,7 +396,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = X4MJ64T45C;
+				DEVELOPMENT_TEAM = 827AL5HLRB;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "sd-smart-parking/Info.plist";
@@ -331,7 +406,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "appMoviles.sd-smart-parking";
+				PRODUCT_BUNDLE_IDENTIFIER = co.edu.uniandes.dbenavid.sdSmartParking;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
@@ -343,9 +418,60 @@
 			};
 			name = Release;
 		};
+		A9965CFE832E4C2C92F0C44A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = X4MJ64T45C;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "appMoviles.sd-smart-parkingTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/sd-smart-parking.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/sd-smart-parking";
+			};
+			name = Debug;
+		};
+		BA2E7575A9CF40EB98006832 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = X4MJ64T45C;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "appMoviles.sd-smart-parkingTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/sd-smart-parking.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/sd-smart-parking";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		2F17E05D5733420BB5F80EB8 /* Build configuration list for PBXNativeTarget "sd-smart-parkingTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A9965CFE832E4C2C92F0C44A /* Debug */,
+				BA2E7575A9CF40EB98006832 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		A21A2E712F6C3EFD005E5098 /* Build configuration list for PBXProject "sd-smart-parking" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/sd-smart-parking/sd-smart-parking/ViewModels/ParkingViewModel.swift
+++ b/sd-smart-parking/sd-smart-parking/ViewModels/ParkingViewModel.swift
@@ -31,6 +31,37 @@ class ParkingViewModel: ObservableObject {
         guard !spots.isEmpty else { return 0 }
         return Double(totalOccupied) / Double(spots.count)
     }
+
+    /// Per-floor availability counts, keyed by floor number.
+    var floorAvailability: [Int: (available: Int, total: Int)] {
+        let grouped = Dictionary(grouping: spots, by: { $0.floor })
+        return grouped.mapValues { floorSpots in
+            let available = floorSpots.filter { $0.isAvailable }.count
+            return (available: available, total: floorSpots.count)
+        }
+    }
+
+    /// The floor with the most available spots, or `nil` when no clear winner.
+    var recommendedFloor: Int? {
+        let avail = floorAvailability
+        guard !avail.isEmpty else { return nil }
+
+        let sorted = avail.sorted { $0.value.available > $1.value.available }
+        let best = sorted[0]
+
+        // No spots available on the best floor
+        guard best.value.available > 0 else { return nil }
+
+        // Tie: if a second floor is within 2 spots, suppress recommendation
+        if sorted.count >= 2 {
+            let second = sorted[1]
+            if best.value.available - second.value.available <= 2 {
+                return nil
+            }
+        }
+
+        return best.key
+    }
  
     // MARK: - Init
  

--- a/sd-smart-parking/sd-smart-parking/Views/Components/FloorBadge.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Components/FloorBadge.swift
@@ -1,0 +1,28 @@
+//
+//  FloorBadge.swift
+//  sd-smart-parking
+//
+
+import SwiftUI
+
+struct FloorBadge: View {
+    let isUrgent: Bool
+
+    var body: some View {
+        Text(isUrgent ? "Last spots!" : "Recommended")
+            .font(.system(size: 12, weight: .semibold))
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .foregroundColor(isUrgent ? .orange : .green)
+            .background((isUrgent ? Color.orange : Color.green).opacity(0.1))
+            .clipShape(Capsule())
+    }
+}
+
+#Preview("Recommended") {
+    FloorBadge(isUrgent: false)
+}
+
+#Preview("Urgent") {
+    FloorBadge(isUrgent: true)
+}

--- a/sd-smart-parking/sd-smart-parking/Views/Parking/SpotsView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Parking/SpotsView.swift
@@ -27,12 +27,56 @@ struct SpotsView: View {
         NavigationStack {
             ScrollView {
                 VStack(alignment: .leading, spacing: 25) {
+                    // Recommendation banner (driver only)
+                    if !authVM.isGerente,
+                       let recommended = vm.recommendedFloor {
+                        let avail = vm.floorAvailability[recommended]?.available ?? 0
+                        let floorSpots = vm.spots
+                            .filter { $0.floor == recommended && $0.isAvailable }
+                            .sorted { $0.number < $1.number }
+                            .prefix(3)
+
+                        VStack(alignment: .leading, spacing: 12) {
+                            HStack(spacing: 8) {
+                                Image(systemName: "sparkles")
+                                    .foregroundColor(.green)
+                                Text("Best floor: Floor \(recommended)")
+                                    .font(.headline)
+                                FloorBadge(isUrgent: avail <= 4)
+                                Spacer()
+                            }
+
+                            Text("\(avail) spots available")
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+
+                            LazyVGrid(columns: columns, spacing: 15) {
+                                ForEach(Array(floorSpots)) { spot in
+                                    SpotCardView(spot: spot, isGerente: false)
+                                }
+                            }
+                        }
+                        .padding()
+                        .background(Color.green.opacity(0.05))
+                        .cornerRadius(16)
+                        .padding(.horizontal)
+                    }
+
                     ForEach(sortedFloors, id: \.self) { floor in // <- usar aquí
                         VStack(alignment: .leading, spacing: 15) {
-                            Text("Floor \(floor)")
-                                .font(.headline)
-                                .foregroundColor(.secondary)
-                                .padding(.horizontal)
+                            HStack {
+                                Text("Floor \(floor)")
+                                    .font(.headline)
+                                    .foregroundColor(.secondary)
+
+                                if !authVM.isGerente,
+                                   let recommended = vm.recommendedFloor,
+                                   recommended == floor {
+                                    let avail = vm.floorAvailability[floor]?.available ?? 0
+                                    FloorBadge(isUrgent: avail <= 4)
+                                }
+                            }
+                            .padding(.horizontal)
                             
                             LazyVGrid(columns: columns, spacing: 15) {
                                 ForEach(vm.spots.filter { $0.floor == floor }.sorted(by: { $0.number < $1.number })) { spot in

--- a/sd-smart-parking/sd-smart-parkingTests/ParkingViewModelTests.swift
+++ b/sd-smart-parking/sd-smart-parkingTests/ParkingViewModelTests.swift
@@ -1,0 +1,132 @@
+//
+//  ParkingViewModelTests.swift
+//  sd-smart-parkingTests
+//
+
+import Foundation
+import Testing
+@testable import sd_smart_parking
+
+// MARK: - Helpers
+
+private func makeSpot(floor: Int, index: Int, available: Bool) -> ParkingSpot {
+    ParkingSpot(
+        id: UUID(),
+        number: floor * 100 + index,
+        floor: floor,
+        isAvailable: available
+    )
+}
+
+private func makeFloor(_ floor: Int, available: Int, total: Int) -> [ParkingSpot] {
+    (1...total).map { i in
+        makeSpot(floor: floor, index: i, available: i <= available)
+    }
+}
+
+// MARK: - floorAvailability tests
+
+@Suite("floorAvailability")
+struct FloorAvailabilityTests {
+
+    @Test func emptySpots() {
+        let vm = ParkingViewModel()
+        vm.spots = []
+        #expect(vm.floorAvailability.isEmpty)
+    }
+
+    @Test func singleFloorAllAvailable() {
+        let vm = ParkingViewModel()
+        vm.spots = makeFloor(1, available: 5, total: 5)
+        let fa = vm.floorAvailability
+        #expect(fa[1]?.available == 5)
+        #expect(fa[1]?.total == 5)
+    }
+
+    @Test func twoFloorsMixed() {
+        let vm = ParkingViewModel()
+        vm.spots = makeFloor(1, available: 3, total: 5) + makeFloor(2, available: 1, total: 5)
+        let fa = vm.floorAvailability
+        #expect(fa[1]?.available == 3)
+        #expect(fa[1]?.total == 5)
+        #expect(fa[2]?.available == 1)
+        #expect(fa[2]?.total == 5)
+    }
+}
+
+// MARK: - recommendedFloor tests
+
+@Suite("recommendedFloor")
+struct RecommendedFloorTests {
+
+    @Test func clearWinner() {
+        let vm = ParkingViewModel()
+        vm.spots = makeFloor(1, available: 10, total: 20)
+                 + makeFloor(2, available: 3, total: 20)
+                 + makeFloor(3, available: 5, total: 20)
+        #expect(vm.recommendedFloor == 1)
+    }
+
+    @Test func tieWithinThreshold() {
+        let vm = ParkingViewModel()
+        vm.spots = makeFloor(1, available: 10, total: 20)
+                 + makeFloor(2, available: 9, total: 20)
+        #expect(vm.recommendedFloor == nil)
+    }
+
+    @Test func tieExactlyAtThreshold() {
+        let vm = ParkingViewModel()
+        vm.spots = makeFloor(1, available: 10, total: 20)
+                 + makeFloor(2, available: 7, total: 20)
+        #expect(vm.recommendedFloor == 1)
+    }
+
+    @Test func allFull() {
+        let vm = ParkingViewModel()
+        vm.spots = makeFloor(1, available: 0, total: 20)
+                 + makeFloor(2, available: 0, total: 20)
+        #expect(vm.recommendedFloor == nil)
+    }
+
+    @Test func allEqualAvailability() {
+        let vm = ParkingViewModel()
+        vm.spots = makeFloor(1, available: 10, total: 20)
+                 + makeFloor(2, available: 10, total: 20)
+                 + makeFloor(3, available: 10, total: 20)
+        #expect(vm.recommendedFloor == nil)
+    }
+
+    @Test func singleFloor() {
+        let vm = ParkingViewModel()
+        vm.spots = makeFloor(1, available: 5, total: 20)
+        #expect(vm.recommendedFloor == 1)
+    }
+
+    @Test func emptySpots() {
+        let vm = ParkingViewModel()
+        vm.spots = []
+        #expect(vm.recommendedFloor == nil)
+    }
+}
+
+// MARK: - Urgency threshold tests
+
+@Suite("urgency")
+struct UrgencyTests {
+
+    @Test func urgentAt4Spots() {
+        let vm = ParkingViewModel()
+        vm.spots = makeFloor(1, available: 4, total: 20)
+                 + makeFloor(2, available: 0, total: 20)
+        let avail = vm.floorAvailability[1]?.available ?? 0
+        #expect(avail <= 4)
+    }
+
+    @Test func notUrgentAt5Spots() {
+        let vm = ParkingViewModel()
+        vm.spots = makeFloor(1, available: 5, total: 20)
+                 + makeFloor(2, available: 0, total: 20)
+        let avail = vm.floorAvailability[1]?.available ?? 0
+        #expect(avail > 4)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds real-time best floor recommendation to the Spots tab for drivers (hidden for gerente)
- Recommendation banner at the top shows the best floor, available count, urgency badge, and a preview of 3 available spots
- Per-floor inline badge ("Recommended" / "Last spots!") on the winning floor's header
- Suppresses recommendation when floors are within 2 spots of each other (tie) or all full
- Adds `sd-smart-parkingTests` target (Swift Testing) with 12 unit tests covering recommendation logic

## Changes

- **ParkingViewModel**: `floorAvailability` and `recommendedFloor` computed properties (pure derivation from `spots`)
- **SpotsView**: recommendation banner + per-floor badge, driver-only
- **FloorBadge**: reusable capsule component (green "Recommended" / orange "Last spots!")
- **project.pbxproj**: new `sd-smart-parkingTests` unit test target

## Test plan

- [x] `build_sim` passes
- [x] `test_sim` passes — 12/12 tests (floor availability, recommendation logic, urgency threshold)
- [x] Manual: log in as driver, open Spots tab, verify banner appears on floor with most availability
- [x] Manual: log in as gerente, verify no banner or badge appears