### PR TITLE
✨ feat(parking): add time-aware dashboard with demand-level banners

### DIFF
--- a/sd-smart-parking/sd-smart-parking/Models/ParkingTimeStatus.swift
+++ b/sd-smart-parking/sd-smart-parking/Models/ParkingTimeStatus.swift
@@ -1,0 +1,135 @@
+//
+//  ParkingTimeStatus.swift
+//  sd-smart-parking
+//
+
+import Foundation
+
+// MARK: - Demand Level
+
+enum DemandLevel: String, Equatable {
+    case peak
+    case valley
+    case normal
+}
+
+// MARK: - Operating Status
+
+enum ParkingOperatingStatus: Equatable {
+    case closed(opensAt: Int)
+    case closingSoon(minutesLeft: Int)
+    case open
+}
+
+// MARK: - Peak Hours Schedule
+
+// TODO(claude): Replace hardcoded schedule with Firestore-derived dynamic values
+struct PeakHoursSchedule {
+
+    // Weekday schedule (Mon–Fri)
+    static let weekdayPeakRanges: [(start: Int, end: Int)] = [(6, 9)]
+    static let weekdayValleyRanges: [(start: Int, end: Int)] = [(12, 15)]
+
+    // Weekend schedule (Sat–Sun): no peaks, valley all operating hours
+    static let weekendPeakRanges: [(start: Int, end: Int)] = []
+    static let weekendValleyRanges: [(start: Int, end: Int)] = [(6, 22)]
+
+    static func isWeekend(at date: Date) -> Bool {
+        let weekday = Calendar.current.component(.weekday, from: date)
+        return weekday == 1 || weekday == 7
+    }
+
+    static func demandLevel(at date: Date) -> DemandLevel {
+        let calendar = Calendar.current
+        let hour = calendar.component(.hour, from: date)
+        let weekend = isWeekend(at: date)
+
+        let peaks = weekend ? weekendPeakRanges : weekdayPeakRanges
+        let valleys = weekend ? weekendValleyRanges : weekdayValleyRanges
+
+        for range in peaks {
+            if hour >= range.start && hour < range.end { return .peak }
+        }
+
+        for range in valleys {
+            if hour >= range.start && hour < range.end { return .valley }
+        }
+
+        return .normal
+    }
+
+    static func operatingStatus(at date: Date, openingHour: Int, closingHour: Int) -> ParkingOperatingStatus {
+        let components = Calendar.current.dateComponents([.hour, .minute], from: date)
+        let hour = components.hour ?? 0
+        let minute = components.minute ?? 0
+
+        if hour < openingHour || hour >= closingHour {
+            return .closed(opensAt: openingHour)
+        }
+
+        let minutesUntilClosing = (closingHour - hour) * 60 - minute
+
+        if minutesUntilClosing <= 30 {
+            return .closingSoon(minutesLeft: minutesUntilClosing)
+        }
+
+        return .open
+    }
+
+    static func transitionCountdown(at date: Date, openingHour: Int, closingHour: Int) -> String? {
+        let status = operatingStatus(at: date, openingHour: openingHour, closingHour: closingHour)
+        guard case .open = status else { return nil }
+
+        let calendar = Calendar.current
+        let components = calendar.dateComponents([.hour, .minute], from: date)
+        let hour = components.hour ?? 0
+        let minute = components.minute ?? 0
+        let currentMinutes = hour * 60 + minute
+        let closingMinutes = closingHour * 60
+        let weekend = isWeekend(at: date)
+
+        let peaks = weekend ? weekendPeakRanges : weekdayPeakRanges
+        let valleys = weekend ? weekendValleyRanges : weekdayValleyRanges
+        let level = demandLevel(at: date)
+
+        switch level {
+        case .peak:
+            if let range = peaks.first(where: { hour >= $0.start && hour < $0.end }) {
+                let endMinutes = range.end * 60
+                if endMinutes >= closingMinutes {
+                    return formatCountdown(closingMinutes - currentMinutes, suffix: "para cierre")
+                }
+                return formatCountdown(endMinutes - currentMinutes, suffix: "para horario normal")
+            }
+        case .valley:
+            if let range = valleys.first(where: { hour >= $0.start && hour < $0.end }) {
+                let endMinutes = range.end * 60
+                if endMinutes >= closingMinutes {
+                    return formatCountdown(closingMinutes - currentMinutes, suffix: "para cierre")
+                }
+                return formatCountdown(endMinutes - currentMinutes, suffix: "para horario normal")
+            }
+        case .normal:
+            var nextEvents: [(minuteMark: Int, label: String)] = []
+            for range in peaks { nextEvents.append((range.start * 60, "horas pico")) }
+            for range in valleys { nextEvents.append((range.start * 60, "horas valle")) }
+            nextEvents.append((closingMinutes, "cierre"))
+
+            if let next = nextEvents
+                .filter({ $0.minuteMark > currentMinutes })
+                .min(by: { $0.minuteMark < $1.minuteMark }) {
+                return formatCountdown(next.minuteMark - currentMinutes, suffix: "para \(next.label)")
+            }
+        }
+        return nil
+    }
+
+    private static func formatCountdown(_ totalMinutes: Int, suffix: String) -> String {
+        let h = totalMinutes / 60
+        let m = totalMinutes % 60
+        if h > 0 {
+            return "\(h)h \(m)m \(suffix)"
+        }
+        return "\(m) min \(suffix)"
+    }
+}

--- a/sd-smart-parking/sd-smart-parking/Models/ParkingTimeStatus.swift
+++ b/sd-smart-parking/sd-smart-parking/Models/ParkingTimeStatus.swift
@@ -23,7 +23,7 @@ enum ParkingOperatingStatus: Equatable {
 
 // MARK: - Peak Hours Schedule
 
-// TODO(claude): Replace hardcoded schedule with Firestore-derived dynamic values
+// TODO: Replace hardcoded schedule with Firestore-derived dynamic values
 struct PeakHoursSchedule {
 
     // Weekday schedule (Mon–Fri)

--- a/sd-smart-parking/sd-smart-parking/Views/Components/ParkingStatusBannerView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Components/ParkingStatusBannerView.swift
@@ -1,0 +1,104 @@
+//
+//  ParkingStatusBannerView.swift
+//  sd-smart-parking
+//
+
+import SwiftUI
+
+struct ParkingStatusBannerView: View {
+    let demandLevel: DemandLevel
+    var countdown: String? = nil
+
+    private var icon: String {
+        switch demandLevel {
+        case .peak:   return "flame.fill"
+        case .valley: return "leaf.fill"
+        case .normal: return "clock.fill"
+        }
+    }
+
+    private var label: String {
+        switch demandLevel {
+        case .peak:   return "Horas Pico"
+        case .valley: return "Horas Valle"
+        case .normal: return "Horario Normal"
+        }
+    }
+
+    private var foregroundColor: Color {
+        switch demandLevel {
+        case .peak:   return Color(.sRGB, red: 0.8, green: 0.4, blue: 0.0)
+        case .valley: return Color(.sRGB, red: 0.1, green: 0.55, blue: 0.15)
+        case .normal: return Color(.sRGB, red: 0.55, green: 0.45, blue: 0.0)
+        }
+    }
+
+    private var backgroundColor: Color {
+        switch demandLevel {
+        case .peak:   return Color.orange.opacity(0.15)
+        case .valley: return Color.green.opacity(0.15)
+        case .normal: return Color.yellow.opacity(0.2)
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: icon)
+                .foregroundColor(foregroundColor)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(label)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(foregroundColor)
+                if let countdown {
+                    Text(countdown)
+                        .font(.system(size: 12))
+                        .foregroundColor(foregroundColor.opacity(0.7))
+                }
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(backgroundColor)
+        .cornerRadius(12)
+    }
+}
+
+struct ClosingSoonBannerView: View {
+    let minutesLeft: Int
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundColor(.red)
+            Text("Cierra en \(minutesLeft) min — planifica tu salida")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(.red)
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(Color.red.opacity(0.1))
+        .cornerRadius(12)
+    }
+}
+
+#Preview("Peak") {
+    ParkingStatusBannerView(demandLevel: .peak, countdown: "1h 30m para horario normal")
+        .padding()
+}
+
+#Preview("Valley") {
+    ParkingStatusBannerView(demandLevel: .valley, countdown: "2h 0m para cierre")
+        .padding()
+}
+
+#Preview("Normal") {
+    ParkingStatusBannerView(demandLevel: .normal, countdown: "45 min para horas pico")
+        .padding()
+}
+
+#Preview("Closing Soon") {
+    ClosingSoonBannerView(minutesLeft: 15)
+        .padding()
+}

--- a/sd-smart-parking/sd-smart-parking/Views/Usuario/Dashboard/DashboardView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Usuario/Dashboard/DashboardView.swift
@@ -37,81 +37,47 @@ struct DashboardView: View {
                     // Este espacio permite que el contenido empiece debajo del header azul
                     Color.clear.frame(height: 80)
 
-                    // MARK: - Main Availability Card
-                    VStack(spacing: 20) {
-                        Text("Available Parking Spots")
-                            .font(.system(size: 16))
-                            .foregroundColor(.gray)
-                        
-                        HStack(alignment: .firstTextBaseline, spacing: 4) {
-                            Text("\(vm.totalAvailable)")
-                                .font(.system(size: 64, weight: .bold))
-                            Text("/ \(vm.spots.count)")
-                                .font(.title2)
-                                .foregroundColor(.gray)
-                        }
-                        
-                        Text(vm.totalAvailable > 0 ? "Available" : "Full")
-                            .font(.system(size: 14, weight: .bold))
-                            .padding(.horizontal, 20)
-                            .padding(.vertical, 8)
-                            .background(vm.totalAvailable > 0 ? Color.green.opacity(0.1) : Color.red.opacity(0.1))
-                            .foregroundColor(vm.totalAvailable > 0 ? .green : .red)
-                            .clipShape(Capsule())
-                        
-                        // Barra de progreso personalizada
-                        GeometryReader { proxy in
-                            ZStack(alignment: .leading) {
-                                Capsule()
-                                    .fill(Color(.systemGray5))
-                                    .frame(height: 8)
-                                
-                                Capsule()
-                                    .fill(vm.occupancyProgress > 0.8 ? Color.orange : Color.green)
-                                    .frame(width: proxy.size.width * CGFloat(vm.occupancyProgress), height: 8)
+                    // MARK: - Time-Aware Content
+                    TimelineView(.periodic(from: Date(), by: 60)) { context in
+                        let now = context.date
+                        let operatingStatus = PeakHoursSchedule.operatingStatus(
+                            at: now,
+                            openingHour: vm.config.openingHour,
+                            closingHour: vm.config.closingHour
+                        )
+                        let demandLevel = PeakHoursSchedule.demandLevel(at: now)
+                        let countdown = PeakHoursSchedule.transitionCountdown(
+                            at: now,
+                            openingHour: vm.config.openingHour,
+                            closingHour: vm.config.closingHour
+                        )
+
+                        VStack(spacing: 0) {
+                            switch operatingStatus {
+                            case .open:
+                                ParkingStatusBannerView(demandLevel: demandLevel, countdown: countdown)
+                                    .padding(.horizontal, 20)
+                                    .padding(.bottom, 12)
+                            case .closingSoon(let mins):
+                                ClosingSoonBannerView(minutesLeft: mins)
+                                    .padding(.horizontal, 20)
+                                    .padding(.bottom, 12)
+                            case .closed:
+                                EmptyView()
                             }
-                        }
-                        .frame(height: 8)
-                        .padding(.horizontal, 20)
-                        
-                        // Mini Cards (Queue & Wait Time)
-                        HStack(spacing: 15) {
-                            miniStatusCard(icon: "car.fill", title: "Queue Length", value: "12")
-                            miniStatusCard(icon: "clock.fill", title: "Est. Wait Time", value: "3 min")
-                        }
-                        
-                        // Botones principales
-                        VStack(spacing: 12) {
-                            Button(action: {withAnimation { selectedTab = 2 }}) {
-                                Label("Navigate to Parking", systemImage: "paperplane.fill")
-                                    .font(.headline)
-                                    .foregroundColor(.white)
-                                    .frame(maxWidth: .infinity)
-                                    .padding()
-                                    .background(Color.blue)
-                                    .cornerRadius(12)
-                            }
-                            
-                            Button(action: {
-                                withAnimation { selectedTab = 1 }
-                            }) {
-                                Label("Spot View", systemImage: "calendar")
-                                    .font(.headline)
-                                    .foregroundColor(.blue)
-                                    .frame(maxWidth: .infinity)
-                                    .padding()
-                                    .background(
-                                        RoundedRectangle(cornerRadius: 12)
-                                            .stroke(Color.blue, lineWidth: 2)
-                                    )
+
+                            switch operatingStatus {
+                            case .closed(let opensAt):
+                                ParkingClosedCardView(
+                                    opensAtHour: opensAt,
+                                    now: now,
+                                    selectedTab: $selectedTab
+                                )
+                            default:
+                                availabilityCard
                             }
                         }
                     }
-                    .padding(24)
-                    .background(Color.white)
-                    .cornerRadius(24)
-                    .shadow(color: .black.opacity(0.1), radius: 15, x: 0, y: 5)
-                    .padding(.horizontal, 20)
                     
                     // MARK: - Bottom Action Cards
                     HStack(spacing: 16) {
@@ -151,6 +117,80 @@ struct DashboardView: View {
         }
     }
     
+    // MARK: - Availability Card
+    @ViewBuilder
+    private var availabilityCard: some View {
+        VStack(spacing: 20) {
+            Text("Available Parking Spots")
+                .font(.system(size: 16))
+                .foregroundColor(.gray)
+
+            HStack(alignment: .firstTextBaseline, spacing: 4) {
+                Text("\(vm.totalAvailable)")
+                    .font(.system(size: 64, weight: .bold))
+                Text("/ \(vm.spots.count)")
+                    .font(.title2)
+                    .foregroundColor(.gray)
+            }
+
+            Text(vm.totalAvailable > 0 ? "Available" : "Full")
+                .font(.system(size: 14, weight: .bold))
+                .padding(.horizontal, 20)
+                .padding(.vertical, 8)
+                .background(vm.totalAvailable > 0 ? Color.green.opacity(0.1) : Color.red.opacity(0.1))
+                .foregroundColor(vm.totalAvailable > 0 ? .green : .red)
+                .clipShape(Capsule())
+
+            GeometryReader { proxy in
+                ZStack(alignment: .leading) {
+                    Capsule()
+                        .fill(Color(.systemGray5))
+                        .frame(height: 8)
+
+                    Capsule()
+                        .fill(vm.occupancyProgress > 0.8 ? Color.orange : Color.green)
+                        .frame(width: proxy.size.width * CGFloat(vm.occupancyProgress), height: 8)
+                }
+            }
+            .frame(height: 8)
+            .padding(.horizontal, 20)
+
+            HStack(spacing: 15) {
+                miniStatusCard(icon: "car.fill", title: "Queue Length", value: "12")
+                miniStatusCard(icon: "clock.fill", title: "Est. Wait Time", value: "3 min")
+            }
+
+            VStack(spacing: 12) {
+                Button(action: { withAnimation { selectedTab = 2 } }) {
+                    Label("Navigate to Parking", systemImage: "paperplane.fill")
+                        .font(.headline)
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.blue)
+                        .cornerRadius(12)
+                }
+
+                Button(action: { withAnimation { selectedTab = 1 } }) {
+                    Label("Spot View", systemImage: "calendar")
+                        .font(.headline)
+                        .foregroundColor(.blue)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(
+                            RoundedRectangle(cornerRadius: 12)
+                                .stroke(Color.blue, lineWidth: 2)
+                        )
+                }
+            }
+        }
+        .padding(24)
+        .background(Color.white)
+        .cornerRadius(24)
+        .shadow(color: .black.opacity(0.1), radius: 15, x: 0, y: 5)
+        .padding(.horizontal, 20)
+    }
+
     private func miniStatusCard(icon: String, title: String, value: String) -> some View {
         VStack(spacing: 8) {
             Image(systemName: icon)

--- a/sd-smart-parking/sd-smart-parking/Views/Usuario/Dashboard/ParkingClosedCardView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Usuario/Dashboard/ParkingClosedCardView.swift
@@ -1,0 +1,101 @@
+//
+//  ParkingClosedCardView.swift
+//  sd-smart-parking
+//
+
+import SwiftUI
+
+struct ParkingClosedCardView: View {
+    let opensAtHour: Int
+    let now: Date
+    @Binding var selectedTab: Int
+
+    private var opensTomorrow: Bool {
+        let currentHour = Calendar.current.component(.hour, from: now)
+        return currentHour >= opensAtHour
+    }
+
+    private var opensLabel: String {
+        if opensTomorrow {
+            return "Abre mañana a las \(opensAtHour):00"
+        }
+        return "Abre hoy a las \(opensAtHour):00"
+    }
+
+    private var countdown: String {
+        let components = Calendar.current.dateComponents([.hour, .minute], from: now)
+        let currentMinutes = (components.hour ?? 0) * 60 + (components.minute ?? 0)
+        let openingMinutes = opensAtHour * 60
+
+        let minutesUntilOpen: Int
+        if currentMinutes < openingMinutes {
+            minutesUntilOpen = openingMinutes - currentMinutes
+        } else {
+            minutesUntilOpen = (24 * 60 - currentMinutes) + openingMinutes
+        }
+
+        let hours = minutesUntilOpen / 60
+        let mins = minutesUntilOpen % 60
+
+        if hours > 0 {
+            return "Abre en \(hours)h \(mins)m"
+        }
+        return "Abre en \(mins)m"
+    }
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "lock.fill")
+                .font(.system(size: 48))
+                .foregroundColor(.gray)
+
+            Text("Estacionamiento Cerrado")
+                .font(.system(size: 24, weight: .bold))
+
+            Text(opensLabel)
+                .font(.system(size: 16))
+                .foregroundColor(.gray)
+
+            Text(countdown)
+                .font(.system(size: 14, weight: .bold))
+                .padding(.horizontal, 20)
+                .padding(.vertical, 8)
+                .background(Color.blue.opacity(0.1))
+                .foregroundColor(.blue)
+                .clipShape(Capsule())
+
+            VStack(spacing: 12) {
+                Button(action: { withAnimation { selectedTab = 2 } }) {
+                    Label("Navigate to Parking", systemImage: "paperplane.fill")
+                        .font(.headline)
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.blue)
+                        .cornerRadius(12)
+                }
+
+                Button(action: { withAnimation { selectedTab = 1 } }) {
+                    Label("Spot View", systemImage: "calendar")
+                        .font(.headline)
+                        .foregroundColor(.blue)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(
+                            RoundedRectangle(cornerRadius: 12)
+                                .stroke(Color.blue, lineWidth: 2)
+                        )
+                }
+            }
+        }
+        .padding(24)
+        .background(Color.white)
+        .cornerRadius(24)
+        .shadow(color: .black.opacity(0.1), radius: 15, x: 0, y: 5)
+        .padding(.horizontal, 20)
+    }
+}
+
+#Preview("Opens Tomorrow") {
+    ParkingClosedCardView(opensAtHour: 6, now: Date(), selectedTab: .constant(0))
+}

--- a/sd-smart-parking/sd-smart-parkingTests/ParkingTimeStatusTests.swift
+++ b/sd-smart-parking/sd-smart-parkingTests/ParkingTimeStatusTests.swift
@@ -1,0 +1,235 @@
+//
+//  ParkingTimeStatusTests.swift
+//  sd-smart-parkingTests
+//
+
+import Foundation
+import Testing
+@testable import sd_smart_parking
+
+// MARK: - Helpers
+
+/// April 9, 2026 = Thursday (weekday)
+private func makeDate(hour: Int, minute: Int = 0) -> Date {
+    var components = DateComponents()
+    components.year = 2026
+    components.month = 4
+    components.day = 9
+    components.hour = hour
+    components.minute = minute
+    return Calendar.current.date(from: components)!
+}
+
+/// April 4, 2026 = Saturday (weekend)
+private func makeWeekendDate(hour: Int, minute: Int = 0) -> Date {
+    var components = DateComponents()
+    components.year = 2026
+    components.month = 4
+    components.day = 4
+    components.hour = hour
+    components.minute = minute
+    return Calendar.current.date(from: components)!
+}
+
+// MARK: - DemandLevel Tests (Weekday)
+
+@Suite("DemandLevel")
+struct DemandLevelTests {
+
+    @Test func peakAt0600() {
+        #expect(PeakHoursSchedule.demandLevel(at: makeDate(hour: 6)) == .peak)
+    }
+
+    @Test func peakAt0830() {
+        #expect(PeakHoursSchedule.demandLevel(at: makeDate(hour: 8, minute: 30)) == .peak)
+    }
+
+    @Test func peakEndsAt0900() {
+        #expect(PeakHoursSchedule.demandLevel(at: makeDate(hour: 9)) == .normal)
+    }
+
+    @Test func valleyAt1200() {
+        #expect(PeakHoursSchedule.demandLevel(at: makeDate(hour: 12)) == .valley)
+    }
+
+    @Test func valleyAt1430() {
+        #expect(PeakHoursSchedule.demandLevel(at: makeDate(hour: 14, minute: 30)) == .valley)
+    }
+
+    @Test func valleyEndsAt1500() {
+        #expect(PeakHoursSchedule.demandLevel(at: makeDate(hour: 15)) == .normal)
+    }
+
+    @Test func normalAt1000() {
+        #expect(PeakHoursSchedule.demandLevel(at: makeDate(hour: 10)) == .normal)
+    }
+
+    @Test func normalAt2000() {
+        #expect(PeakHoursSchedule.demandLevel(at: makeDate(hour: 20)) == .normal)
+    }
+
+    @Test func normalAt0500() {
+        #expect(PeakHoursSchedule.demandLevel(at: makeDate(hour: 5)) == .normal)
+    }
+}
+
+// MARK: - DemandLevel Tests (Weekend)
+
+@Suite("DemandLevelWeekend")
+struct DemandLevelWeekendTests {
+
+    @Test func weekendIsDetected() {
+        #expect(PeakHoursSchedule.isWeekend(at: makeWeekendDate(hour: 12)))
+    }
+
+    @Test func weekdayIsNotWeekend() {
+        #expect(!PeakHoursSchedule.isWeekend(at: makeDate(hour: 12)))
+    }
+
+    @Test func weekendMorningIsValley() {
+        #expect(PeakHoursSchedule.demandLevel(at: makeWeekendDate(hour: 7)) == .valley)
+    }
+
+    @Test func weekendPeakHourIsValleyInstead() {
+        #expect(PeakHoursSchedule.demandLevel(at: makeWeekendDate(hour: 8)) == .valley)
+    }
+
+    @Test func weekendAfternoonIsValley() {
+        #expect(PeakHoursSchedule.demandLevel(at: makeWeekendDate(hour: 14)) == .valley)
+    }
+
+    @Test func weekendEveningIsValley() {
+        #expect(PeakHoursSchedule.demandLevel(at: makeWeekendDate(hour: 20)) == .valley)
+    }
+
+    @Test func weekendOutsideHoursIsNormal() {
+        #expect(PeakHoursSchedule.demandLevel(at: makeWeekendDate(hour: 3)) == .normal)
+    }
+}
+
+// MARK: - OperatingStatus Tests
+
+@Suite("OperatingStatus")
+struct OperatingStatusTests {
+
+    @Test func closedAt0300() {
+        let status = PeakHoursSchedule.operatingStatus(at: makeDate(hour: 3), openingHour: 6, closingHour: 22)
+        #expect(status == .closed(opensAt: 6))
+    }
+
+    @Test func closedAt2300() {
+        let status = PeakHoursSchedule.operatingStatus(at: makeDate(hour: 23), openingHour: 6, closingHour: 22)
+        #expect(status == .closed(opensAt: 6))
+    }
+
+    @Test func closedExactlyAtClosing() {
+        let status = PeakHoursSchedule.operatingStatus(at: makeDate(hour: 22), openingHour: 6, closingHour: 22)
+        #expect(status == .closed(opensAt: 6))
+    }
+
+    @Test func openAt0600() {
+        let status = PeakHoursSchedule.operatingStatus(at: makeDate(hour: 6), openingHour: 6, closingHour: 22)
+        #expect(status == .open)
+    }
+
+    @Test func openAt1200() {
+        let status = PeakHoursSchedule.operatingStatus(at: makeDate(hour: 12), openingHour: 6, closingHour: 22)
+        #expect(status == .open)
+    }
+
+    @Test func closingSoonAt2135() {
+        let status = PeakHoursSchedule.operatingStatus(at: makeDate(hour: 21, minute: 35), openingHour: 6, closingHour: 22)
+        #expect(status == .closingSoon(minutesLeft: 25))
+    }
+
+    @Test func closingSoonAt2145() {
+        let status = PeakHoursSchedule.operatingStatus(at: makeDate(hour: 21, minute: 45), openingHour: 6, closingHour: 22)
+        #expect(status == .closingSoon(minutesLeft: 15))
+    }
+
+    @Test func notClosingSoonAt2100() {
+        let status = PeakHoursSchedule.operatingStatus(at: makeDate(hour: 21), openingHour: 6, closingHour: 22)
+        #expect(status == .open)
+    }
+
+    @Test func closingSoonEdgeAt2130() {
+        let status = PeakHoursSchedule.operatingStatus(at: makeDate(hour: 21, minute: 30), openingHour: 6, closingHour: 22)
+        #expect(status == .closingSoon(minutesLeft: 30))
+    }
+}
+
+// MARK: - Custom Hours Tests
+
+@Suite("OperatingStatusCustomHours")
+struct OperatingStatusCustomHoursTests {
+
+    @Test func customHoursOpen() {
+        let status = PeakHoursSchedule.operatingStatus(at: makeDate(hour: 8), openingHour: 8, closingHour: 20)
+        #expect(status == .open)
+    }
+
+    @Test func customHoursClosed() {
+        let status = PeakHoursSchedule.operatingStatus(at: makeDate(hour: 7), openingHour: 8, closingHour: 20)
+        #expect(status == .closed(opensAt: 8))
+    }
+
+    @Test func customHoursClosingSoon() {
+        let status = PeakHoursSchedule.operatingStatus(at: makeDate(hour: 19, minute: 35), openingHour: 8, closingHour: 20)
+        #expect(status == .closingSoon(minutesLeft: 25))
+    }
+}
+
+// MARK: - Transition Countdown Tests
+
+@Suite("TransitionCountdown")
+struct TransitionCountdownTests {
+
+    @Test func peakShowsCountdownToNormal() {
+        let result = PeakHoursSchedule.transitionCountdown(
+            at: makeDate(hour: 7, minute: 30), openingHour: 6, closingHour: 22
+        )
+        #expect(result == "1h 30m para horario normal")
+    }
+
+    @Test func valleyShowsCountdownToNormal() {
+        let result = PeakHoursSchedule.transitionCountdown(
+            at: makeDate(hour: 13), openingHour: 6, closingHour: 22
+        )
+        #expect(result == "2h 0m para horario normal")
+    }
+
+    @Test func normalShowsNextValley() {
+        let result = PeakHoursSchedule.transitionCountdown(
+            at: makeDate(hour: 10), openingHour: 6, closingHour: 22
+        )
+        #expect(result == "2h 0m para horas valle")
+    }
+
+    @Test func normalShowsClosingWhenNoMoreTransitions() {
+        let result = PeakHoursSchedule.transitionCountdown(
+            at: makeDate(hour: 16), openingHour: 6, closingHour: 22
+        )
+        #expect(result == "6h 0m para cierre")
+    }
+
+    @Test func weekendValleyShowsClosingCountdown() {
+        let result = PeakHoursSchedule.transitionCountdown(
+            at: makeWeekendDate(hour: 10), openingHour: 6, closingHour: 22
+        )
+        #expect(result == "12h 0m para cierre")
+    }
+
+    @Test func closedReturnsNil() {
+        let result = PeakHoursSchedule.transitionCountdown(
+            at: makeDate(hour: 3), openingHour: 6, closingHour: 22
+        )
+        #expect(result == nil)
+    }
+
+    @Test func closingSoonReturnsNil() {
+        let result = PeakHoursSchedule.transitionCountdown(
+            at: makeDate(hour: 21, minute: 45), openingHour: 6, closingHour: 22
+        )
+        #expect(result == nil)
+    }
+}


### PR DESCRIPTION
## Summary

- **Context-aware feature:** the driver dashboard now adapts its content based on two temporal dimensions — time of day and day of week.
- **Demand-level banners** show peak (6–9 weekdays), valley (12–15 weekdays, all-day weekends), or normal hours with a live countdown to the next transition (e.g., "2h 0m para horas valle").
- **Operating-hours awareness:** replaces the availability card with a "Estacionamiento Cerrado" card outside hours, showing "Abre mañana a las 6:00" or "Abre hoy a las 6:00" with a countdown. Amber closing-soon warning within 30 min of close.
- **Color-coded urgency gradient:** green (valley) → amber (normal) → orange (peak) → red (closing soon) → grey (closed).
- **Spanish localization** for all new status strings.
- **35 new pure tests** across 6 suites covering weekday/weekend demand levels, operating status boundaries, custom hours, and transition countdown edge cases. All 47 tests pass.

## Files changed

| File | Change |
|---|---|
| `Models/ParkingTimeStatus.swift` | New — `DemandLevel`, `ParkingOperatingStatus`, `PeakHoursSchedule` with weekday/weekend schedules and transition countdown |
| `Views/Components/ParkingStatusBannerView.swift` | New — demand-level banner + closing-soon banner |
| `Views/Usuario/Dashboard/ParkingClosedCardView.swift` | New — closed-hours card with today/tomorrow awareness |
| `Views/Usuario/Dashboard/DashboardView.swift` | Modified — `TimelineView` wrapper, conditional banners and card switching |
| `sd-smart-parkingTests/ParkingTimeStatusTests.swift` | New — 35 pure tests |

## Test plan

- [x] Open app during operating hours (6:00–22:00) on a weekday → demand-level banner visible above availability card with countdown subtitle
- [x] Open app during peak hours (6–9 weekday) → orange "Horas Pico" banner
- [x] Open app during valley hours (12–15 weekday) → green "Horas Valle" banner
- [x] Open app on a weekend during operating hours → green "Horas Valle" banner all day
- [x] Open app outside operating hours → "Estacionamiento Cerrado" card with countdown; shows "mañana" if past closing, "hoy" if before opening
- [x] Open app within 30 min of closing → red "Cierra en X min" warning banner
- [x] Wait 60 seconds → countdown updates automatically
- [x] Availability card in open state → unchanged from before this PR

<!-- TODO: link issue -->