### PR TITLE
✨ feat(ios): add license plate OCR scanner for vehicle records

### DIFF
--- a/sd-smart-parking/sd-smart-parking/Core/ColombianPlateValidator.swift
+++ b/sd-smart-parking/sd-smart-parking/Core/ColombianPlateValidator.swift
@@ -1,0 +1,52 @@
+//
+//  ColombianPlateValidator.swift
+//  sd-smart-parking
+//
+
+import Foundation
+
+// MARK: - Strategy protocol
+
+struct PlateMatch {
+    let plate: String      // normalized, e.g. "ABC123"
+    let confidence: Float  // from VNRecognizedText.confidence
+}
+
+protocol PlateValidationStrategy {
+    /// Finds the first plate matching this strategy's format among OCR candidates.
+    func findPlate(in candidates: [(text: String, confidence: Float)]) -> PlateMatch?
+}
+
+// MARK: - Colombian plate strategy (ABC123)
+
+struct ColombianPlateStrategy: PlateValidationStrategy {
+    private static let regex = try! NSRegularExpression(pattern: "^[A-Z]{3}[0-9]{3}$")
+
+    /// Characters that Vision may detect at the separator position on Colombian plates
+    /// (raised dot between letters and digits). Strip before matching.
+    private static let separators = CharacterSet(charactersIn: ".-·•–—")
+        .union(.whitespaces)
+        .union(.punctuationCharacters)
+
+    func findPlate(in candidates: [(text: String, confidence: Float)]) -> PlateMatch? {
+        for candidate in candidates {
+            let stripped = candidate.text
+                .uppercased()
+                .components(separatedBy: ColombianPlateStrategy.separators)
+                .joined()
+
+            let range = NSRange(stripped.startIndex..., in: stripped)
+            if ColombianPlateStrategy.regex.firstMatch(in: stripped, range: range) != nil {
+                return PlateMatch(plate: stripped, confidence: candidate.confidence)
+            }
+        }
+        return nil
+    }
+}
+
+// MARK: - Convenience free function (keeps call sites simple)
+
+/// Default strategy: Colombian plates.
+func findColombianPlate(in candidates: [(text: String, confidence: Float)]) -> PlateMatch? {
+    ColombianPlateStrategy().findPlate(in: candidates)
+}

--- a/sd-smart-parking/sd-smart-parking/Info.plist
+++ b/sd-smart-parking/sd-smart-parking/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>Location poara viajar</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -16,8 +14,6 @@
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
-	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -31,12 +27,16 @@
 			</array>
 		</dict>
 	</array>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>GIDClientID</key>
 	<string>19078843613-p56jc0qiint7lq72gin826ffhoitvnq3.apps.googleusercontent.com</string>
 	<key>NSCameraUsageDescription</key>
-	<string>The camera is used to scan QR codes at parking spots to confirm your reservation.</string>
+	<string>The camera is used to scan QR codes at parking spots and to recognize vehicle license plates.</string>
 	<key>NSFaceIDUsageDescription</key>
 	<string>Face ID lets you sign in to SD Parking without entering your password.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Location poara viajar</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/sd-smart-parking/sd-smart-parking/Views/Gerente/CreateRecordView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Gerente/CreateRecordView.swift
@@ -17,6 +17,7 @@ struct CreateRecordView: View {
     @State private var ownerEmail: String = ""
     @State private var ocrConfidence: Double = 1.0
     @State private var showConfirmation: Bool = false
+    @State private var showPlateScanner: Bool = false
 
     var isFormValid: Bool {
         plate.trimmingCharacters(in: .whitespaces).count >= 3
@@ -33,6 +34,11 @@ struct CreateRecordView: View {
                             .textInputAutocapitalization(.characters)
                             .autocorrectionDisabled()
                             .font(.system(size: 22, weight: .bold))
+                    }
+                    Button {
+                        showPlateScanner = true
+                    } label: {
+                        Label("Scan Plate", systemImage: "camera.viewfinder")
                     }
                 } header: {
                     Label("License Plate", systemImage: "rectangle.fill")
@@ -130,6 +136,12 @@ struct CreateRecordView: View {
                 Button("OK") { dismiss() }
             } message: {
                 Text("The record for plate \(plate.uppercased()) was created successfully.")
+            }
+            .sheet(isPresented: $showPlateScanner) {
+                PlateOCRSheet { recognizedPlate, recognizedConfidence in
+                    plate = recognizedPlate
+                    ocrConfidence = recognizedConfidence
+                }
             }
         }
     }

--- a/sd-smart-parking/sd-smart-parking/Views/Gerente/PlateOCRScannerView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Gerente/PlateOCRScannerView.swift
@@ -1,0 +1,313 @@
+//
+//  PlateOCRScannerView.swift
+//  sd-smart-parking
+//
+
+import SwiftUI
+import AVFoundation
+import Vision
+
+// MARK: - UIKit camera view for plate OCR
+
+struct PlateOCRCameraView: UIViewRepresentable {
+    let onPlateRecognized: (String, Float) -> Void
+    let onError: (String) -> Void
+    @Binding var captureRequested: Bool
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onPlateRecognized: onPlateRecognized, onError: onError)
+    }
+
+    func makeUIView(context: Context) -> PreviewView {
+        let view = PreviewView()
+        context.coordinator.configure(view: view)
+        return view
+    }
+
+    func updateUIView(_ uiView: PreviewView, context: Context) {
+        if captureRequested {
+            context.coordinator.capturePhoto()
+            DispatchQueue.main.async { captureRequested = false }
+        }
+    }
+
+    // MARK: - Coordinator (AVCapturePhotoCaptureDelegate)
+
+    class Coordinator: NSObject, AVCapturePhotoCaptureDelegate {
+        let onPlateRecognized: (String, Float) -> Void
+        let onError: (String) -> Void
+        private var session: AVCaptureSession?
+        private var photoOutput: AVCapturePhotoOutput?
+
+        init(onPlateRecognized: @escaping (String, Float) -> Void,
+             onError: @escaping (String) -> Void) {
+            self.onPlateRecognized = onPlateRecognized
+            self.onError = onError
+        }
+
+        func configure(view: PreviewView) {
+            switch AVCaptureDevice.authorizationStatus(for: .video) {
+            case .authorized:
+                startSession(view: view)
+            case .notDetermined:
+                AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in
+                    DispatchQueue.main.async {
+                        if granted { self?.startSession(view: view) }
+                        else { self?.onError("Camera access denied.") }
+                    }
+                }
+            default:
+                onError("Camera access is not allowed. Enable it in Settings.")
+            }
+        }
+
+        private func startSession(view: PreviewView) {
+            let session = AVCaptureSession()
+            self.session = session
+
+            guard let device = AVCaptureDevice.default(for: .video),
+                  let input = try? AVCaptureDeviceInput(device: device) else {
+                onError("Could not access the camera.")
+                return
+            }
+            session.addInput(input)
+
+            let output = AVCapturePhotoOutput()
+            session.addOutput(output)
+            self.photoOutput = output
+
+            DispatchQueue.main.async {
+                let preview = AVCaptureVideoPreviewLayer(session: session)
+                preview.videoGravity = .resizeAspectFill
+                view.previewLayer = preview
+                view.layer.insertSublayer(preview, at: 0)
+                preview.frame = view.bounds
+            }
+
+            DispatchQueue.global(qos: .userInitiated).async {
+                session.startRunning()
+            }
+        }
+
+        func capturePhoto() {
+            guard let photoOutput else { return }
+            let settings = AVCapturePhotoSettings()
+            photoOutput.capturePhoto(with: settings, delegate: self)
+        }
+
+        func photoOutput(_ output: AVCapturePhotoOutput,
+                         didFinishProcessingPhoto photo: AVCapturePhoto,
+                         error: Error?) {
+            if let error {
+                DispatchQueue.main.async { self.onError(error.localizedDescription) }
+                return
+            }
+
+            guard let cgImage = photo.cgImageRepresentation() else {
+                DispatchQueue.main.async { self.onError("Could not process the captured image.") }
+                return
+            }
+
+            let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+            let request = VNRecognizeTextRequest { [weak self] request, error in
+                guard let self else { return }
+
+                if let error {
+                    DispatchQueue.main.async { self.onError(error.localizedDescription) }
+                    return
+                }
+
+                guard let observations = request.results as? [VNRecognizedTextObservation] else {
+                    DispatchQueue.main.async { self.onError("No text found in image.") }
+                    return
+                }
+
+                let candidates: [(text: String, confidence: Float)] = observations.compactMap { obs in
+                    guard let top = obs.topCandidates(1).first else { return nil }
+                    return (text: top.string, confidence: top.confidence)
+                }
+
+                DispatchQueue.main.async {
+                    if let match = findColombianPlate(in: candidates) {
+                        self.onPlateRecognized(match.plate, match.confidence)
+                    } else {
+                        self.onError("No valid license plate found. Try again.")
+                    }
+                }
+            }
+            request.recognitionLevel = .accurate
+
+            do {
+                try handler.perform([request])
+            } catch {
+                DispatchQueue.main.async { self.onError(error.localizedDescription) }
+            }
+        }
+    }
+
+    // MARK: - UIView that hosts the preview layer
+
+    class PreviewView: UIView {
+        var previewLayer: AVCaptureVideoPreviewLayer? {
+            didSet { previewLayer?.frame = bounds }
+        }
+
+        override func layoutSubviews() {
+            super.layoutSubviews()
+            previewLayer?.frame = bounds
+        }
+    }
+}
+
+// MARK: - Sheet for plate OCR scanning
+
+struct PlateOCRSheet: View {
+    let onPlateScanned: (String, Double) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var state: PlateOCRState = .scanning
+    @State private var captureRequested: Bool = false
+
+    private enum PlateOCRState {
+        case scanning
+        case processing
+        case recognized(plate: String, confidence: Float)
+        case error(String)
+    }
+
+    private var isScanning: Bool {
+        switch state {
+        case .scanning, .processing: return true
+        default: return false
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                if isScanning {
+                    cameraView
+                }
+
+                switch state {
+                case .scanning, .processing:
+                    EmptyView() // camera + overlay handled above
+                case .recognized(let plate, let confidence):
+                    recognizedView(plate: plate, confidence: confidence)
+                case .error(let message):
+                    errorView(message: message)
+                }
+
+                Spacer()
+            }
+            .navigationTitle("Scan License Plate")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+    }
+
+    // MARK: - State views
+
+    /// Camera stays mounted during both `.scanning` and `.processing` so the
+    /// coordinator survives long enough to finish the capture + Vision pipeline.
+    private var cameraView: some View {
+        VStack(spacing: 16) {
+            Text("Point the camera at the license plate.")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .padding(.top)
+
+            ZStack {
+                PlateOCRCameraView(
+                    onPlateRecognized: { plate, confidence in
+                        state = .recognized(plate: plate, confidence: confidence)
+                    },
+                    onError: { message in
+                        state = .error(message)
+                    },
+                    captureRequested: $captureRequested
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 20))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 20)
+                        .stroke(Color.white.opacity(0.6), lineWidth: 2)
+                )
+
+                if case .processing = state {
+                    RoundedRectangle(cornerRadius: 20)
+                        .fill(.ultraThinMaterial)
+                    ProgressView("Recognizing plate...")
+                }
+            }
+            .frame(height: 320)
+            .padding(.horizontal)
+
+            Button {
+                state = .processing
+                captureRequested = true
+            } label: {
+                Label("Capture", systemImage: "camera.shutter.button")
+                    .font(.headline)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .disabled({ if case .processing = state { return true }; return false }())
+        }
+    }
+
+    private func recognizedView(plate: String, confidence: Float) -> some View {
+        VStack(spacing: 20) {
+            Spacer()
+
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 48))
+                .foregroundColor(.green)
+
+            Text(plate)
+                .font(.system(size: 40, weight: .bold, design: .monospaced))
+
+            HStack(spacing: 16) {
+                Button("Rescan") {
+                    state = .scanning
+                }
+                .buttonStyle(.bordered)
+
+                Button("Use Plate") {
+                    onPlateScanned(plate, Double(confidence))
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+            }
+            .controlSize(.large)
+
+            Spacer()
+        }
+    }
+
+    private func errorView(message: String) -> some View {
+        VStack(spacing: 16) {
+            Spacer()
+
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 48))
+                .foregroundColor(.red)
+
+            Text(message)
+                .font(.subheadline)
+                .foregroundColor(.red)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
+
+            Button("Try Again") {
+                state = .scanning
+            }
+            .buttonStyle(.borderedProminent)
+
+            Spacer()
+        }
+    }
+}

--- a/sd-smart-parking/sd-smart-parkingTests/ColombianPlateValidatorTests.swift
+++ b/sd-smart-parking/sd-smart-parkingTests/ColombianPlateValidatorTests.swift
@@ -1,0 +1,131 @@
+//
+//  ColombianPlateValidatorTests.swift
+//  sd-smart-parkingTests
+//
+
+import Foundation
+import Testing
+@testable import sd_smart_parking
+
+// MARK: - Valid plate cases
+
+@Suite("ColombianPlateValidator")
+struct ColombianPlateValidatorTests {
+
+    @Test func validStandardPlate() {
+        let result = findColombianPlate(in: [("ABC123", 0.95)])
+        #expect(result?.plate == "ABC123")
+        #expect(result?.confidence == 0.95)
+    }
+
+    @Test func validLowercaseNormalized() {
+        let result = findColombianPlate(in: [("abc123", 0.90)])
+        #expect(result?.plate == "ABC123")
+    }
+
+    @Test func validWithSurroundingText() {
+        let result = findColombianPlate(in: [
+            ("VEHICLE", 0.80),
+            ("XYZ789", 0.92),
+            ("PARKING", 0.85)
+        ])
+        #expect(result?.plate == "XYZ789")
+        #expect(result?.confidence == 0.92)
+    }
+
+    @Test func validFirstMatchReturned() {
+        let result = findColombianPlate(in: [("ABC123", 0.90), ("DEF456", 0.95)])
+        #expect(result?.plate == "ABC123")
+    }
+
+    @Test func validWithWhitespace() {
+        let result = findColombianPlate(in: [("ABC 123", 0.90)])
+        #expect(result?.plate == "ABC123")
+    }
+
+    @Test func validWithDotSeparator() {
+        let result = findColombianPlate(in: [("ABC.123", 0.91)])
+        #expect(result?.plate == "ABC123")
+    }
+
+    @Test func validWithDashSeparator() {
+        let result = findColombianPlate(in: [("ABC-123", 0.89)])
+        #expect(result?.plate == "ABC123")
+    }
+
+    @Test func validWithMiddleDot() {
+        let result = findColombianPlate(in: [("ABC·123", 0.87)])
+        #expect(result?.plate == "ABC123")
+    }
+
+    @Test func validAmongCityAndOtherText() {
+        let result = findColombianPlate(in: [
+            ("BOGOTÁ", 0.85),
+            ("COLOMBIA", 0.80),
+            ("ABC·123", 0.92),
+            ("D.C.", 0.70)
+        ])
+        #expect(result?.plate == "ABC123")
+        #expect(result?.confidence == 0.92)
+    }
+}
+
+// MARK: - No-match cases
+
+@Suite("ColombianPlateValidatorNoMatch")
+struct ColombianPlateValidatorNoMatchTests {
+
+    @Test func emptyArray() {
+        let result = findColombianPlate(in: [])
+        #expect(result == nil)
+    }
+
+    @Test func noMatchingCandidates() {
+        let result = findColombianPlate(in: [("HELLO", 0.90), ("WORLD", 0.85)])
+        #expect(result == nil)
+    }
+
+    @Test func tooFewLetters() {
+        let result = findColombianPlate(in: [("AB1234", 0.90)])
+        #expect(result == nil)
+    }
+
+    @Test func tooManyLetters() {
+        let result = findColombianPlate(in: [("ABCD12", 0.90)])
+        #expect(result == nil)
+    }
+
+    @Test func digitsFirst() {
+        let result = findColombianPlate(in: [("123ABC", 0.90)])
+        #expect(result == nil)
+    }
+
+    @Test func tooShort() {
+        let result = findColombianPlate(in: [("ABC12", 0.90)])
+        #expect(result == nil)
+    }
+
+    @Test func tooLong() {
+        let result = findColombianPlate(in: [("ABC1234", 0.90)])
+        #expect(result == nil)
+    }
+}
+
+// MARK: - Strategy protocol tests
+
+@Suite("PlateValidationStrategy")
+struct PlateValidationStrategyTests {
+
+    @Test func colombianStrategyDirectly() {
+        let strategy: PlateValidationStrategy = ColombianPlateStrategy()
+        let result = strategy.findPlate(in: [("XYZ789", 0.88)])
+        #expect(result?.plate == "XYZ789")
+        #expect(result?.confidence == 0.88)
+    }
+
+    @Test func colombianStrategyNoMatch() {
+        let strategy: PlateValidationStrategy = ColombianPlateStrategy()
+        let result = strategy.findPlate(in: [("NOT-A-PLATE", 0.90)])
+        #expect(result == nil)
+    }
+}


### PR DESCRIPTION
## Summary

- Add camera-based license plate recognition to the Gerente record creation flow using Apple's Vision framework (`VNRecognizeTextRequest` with `.accurate` recognition level)
- Implement `PlateValidationStrategy` protocol with `ColombianPlateStrategy` — validates plates against the Colombian format `[A-Z]{3}[0-9]{3}`, stripping separator dots/dashes that appear on real plates
- Wire "Scan Plate" button into `CreateRecordView` that auto-fills both the plate text and OCR confidence fields on successful recognition
- Update `NSCameraUsageDescription` to cover both QR scanning and plate recognition
- Add 18 unit tests for the plate validator (valid plates, separator handling, no-match cases, strategy protocol)

## Changes

| File | Change |
|---|---|
| `Core/ColombianPlateValidator.swift` | **New** — `PlateValidationStrategy` protocol + `ColombianPlateStrategy` |
| `Views/Gerente/PlateOCRScannerView.swift` | **New** — `PlateOCRCameraView` (UIViewRepresentable) + `PlateOCRSheet` (SwiftUI) |
| `Views/Gerente/CreateRecordView.swift` | **Modified** — added scan button + sheet presentation |
| `Info.plist` | **Modified** — updated camera usage description |
| `ColombianPlateValidatorTests.swift` | **New** — 18 tests across 3 suites |

## Test plan

- [x] Build succeeds on simulator (`build_sim` passed on iPhone 17 Pro, iOS 26.4)
- [x] All 65 tests pass (`test_sim` — 18 new + 47 existing)
- [x] On device: navigate to Gerente → Registro Vehiculos → New Record → tap "Scan Plate"
- [x] Point camera at a Colombian plate (or paper with "ABC123") → tap Capture → plate recognized
- [x] Tap "Use Plate" → plate and confidence auto-fill in the form
- [x] Tap "Rescan" → returns to camera
- [x] Invalid image → shows error with "Try Again" option
- [x] Manual plate entry still works as before (fallback)

<!-- TODO: link issue -->