### PR TITLE
✨ feat(ios): add calendar export and trip planner for parking sessions

### DIFF
--- a/sd-smart-parking/sd-smart-parking/Info.plist
+++ b/sd-smart-parking/sd-smart-parking/Info.plist
@@ -31,6 +31,8 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>GIDClientID</key>
 	<string>19078843613-p56jc0qiint7lq72gin826ffhoitvnq3.apps.googleusercontent.com</string>
+	<key>NSCalendarsWriteOnlyAccessUsageDescription</key>
+	<string>SD Parking adds your parking session to Calendar so you can track when and where you parked.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>The camera is used to scan QR codes at parking spots and to recognize vehicle license plates.</string>
 	<key>NSFaceIDUsageDescription</key>

--- a/sd-smart-parking/sd-smart-parking/ViewModels/CalendarExportViewModel.swift
+++ b/sd-smart-parking/sd-smart-parking/ViewModels/CalendarExportViewModel.swift
@@ -1,0 +1,113 @@
+//
+//  CalendarExportViewModel.swift
+//  sd-smart-parking
+//
+
+import Combine
+import EventKit
+import Foundation
+
+// MARK: - Protocol for testing boundary
+
+protocol CalendarEventStoring {
+    func authorizationStatus(for entityType: EKEntityType) -> EKAuthorizationStatus
+    func requestWriteOnlyAccessToEvents() async throws -> Bool
+    func save(_ event: EKEvent, span: EKSpan, commit: Bool) throws
+    func makeEvent() -> EKEvent
+}
+
+extension EKEventStore: CalendarEventStoring {
+    func authorizationStatus(for entityType: EKEntityType) -> EKAuthorizationStatus {
+        EKEventStore.authorizationStatus(for: entityType)
+    }
+
+    func makeEvent() -> EKEvent {
+        let event = EKEvent(eventStore: self)
+        event.calendar = self.defaultCalendarForNewEvents
+        return event
+    }
+}
+
+// MARK: - ViewModel
+
+class CalendarExportViewModel: ObservableObject {
+    @Published var showAlert = false
+    @Published var alertTitle = ""
+    @Published var alertMessage = ""
+
+    private let store: CalendarEventStoring
+
+    init(store: CalendarEventStoring = EKEventStore()) {
+        self.store = store
+    }
+
+    func exportEvent(record: VehicleRecord, parkingName: String, closingHour: Int) async {
+        let status = store.authorizationStatus(for: .event)
+
+        switch status {
+        case .notDetermined:
+            do {
+                let granted = try await store.requestWriteOnlyAccessToEvents()
+                if granted {
+                    await saveEvent(record: record, parkingName: parkingName, closingHour: closingHour)
+                } else {
+                    await showDeniedAlert()
+                }
+            } catch {
+                await showErrorAlert(error)
+            }
+        case .writeOnly, .fullAccess, .authorized:
+            await saveEvent(record: record, parkingName: parkingName, closingHour: closingHour)
+        case .denied, .restricted:
+            await showDeniedAlert()
+        @unknown default:
+            await showDeniedAlert()
+        }
+    }
+
+    // MARK: - Private
+
+    private func saveEvent(record: VehicleRecord, parkingName: String, closingHour: Int) async {
+        let event = store.makeEvent()
+        event.title = "Parked at SD Building \u{2014} \(record.plate)"
+        event.location = "\(parkingName), Universidad de los Andes"
+        event.startDate = record.timestamp
+
+        // End = min(start + 2h, closingHour on the same day)
+        let calendar = Calendar.current
+        let twoHoursLater = record.timestamp.addingTimeInterval(2 * 3600)
+        let closingDate = calendar.date(bySettingHour: closingHour, minute: 0, second: 0, of: record.timestamp) ?? twoHoursLater
+        event.endDate = min(twoHoursLater, closingDate)
+
+        do {
+            try store.save(event, span: .thisEvent, commit: true)
+            await showSuccessAlert()
+        } catch {
+            await showErrorAlert(error)
+        }
+    }
+
+    private func showSuccessAlert() async {
+        await MainActor.run {
+            alertTitle = "Event Added"
+            alertMessage = "Your parking session was added to Calendar."
+            showAlert = true
+        }
+    }
+
+    private func showDeniedAlert() async {
+        await MainActor.run {
+            alertTitle = "Calendar Access Denied"
+            alertMessage = "Enable calendar access in Settings to export parking events."
+            showAlert = true
+        }
+    }
+
+    private func showErrorAlert(_ error: Error) async {
+        await MainActor.run {
+            alertTitle = "Error"
+            alertMessage = error.localizedDescription
+            showAlert = true
+        }
+    }
+}

--- a/sd-smart-parking/sd-smart-parking/ViewModels/TripPlannerViewModel.swift
+++ b/sd-smart-parking/sd-smart-parking/ViewModels/TripPlannerViewModel.swift
@@ -1,0 +1,165 @@
+//
+//  TripPlannerViewModel.swift
+//  sd-smart-parking
+//
+
+import Combine
+import EventKit
+import Foundation
+
+class TripPlannerViewModel: ObservableObject {
+    @Published var arrivalDate: Date
+    @Published var leaveDate: Date
+    @Published var showAlert = false
+    @Published var alertTitle = ""
+    @Published var alertMessage = ""
+    @Published var didExport = false
+
+    private let store: CalendarEventStoring
+
+    init(store: CalendarEventStoring = EKEventStore()) {
+        self.store = store
+        let calendar = Calendar.current
+        let now = Date()
+        let nextHour = calendar.date(byAdding: .hour, value: 1, to: now)!
+        let arrival = calendar.date(bySetting: .minute, value: 0, of: nextHour) ?? nextHour
+        self.arrivalDate = arrival
+        self.leaveDate = arrival.addingTimeInterval(3600) // +1h default
+    }
+
+    // MARK: - Computed
+
+    var durationHours: Double {
+        max(leaveDate.timeIntervalSince(arrivalDate) / 3600, 0)
+    }
+
+    var demandLevel: DemandLevel {
+        PeakHoursSchedule.demandLevel(at: arrivalDate)
+    }
+
+    var isPeak: Bool {
+        demandLevel == .peak
+    }
+
+    func arrivalCountdown(openingHour: Int, closingHour: Int) -> String? {
+        PeakHoursSchedule.transitionCountdown(at: arrivalDate, openingHour: openingHour, closingHour: closingHour)
+    }
+
+    // MARK: - Validation
+
+    func isArrivalValid(openingHour: Int, closingHour: Int) -> Bool {
+        let hour = Calendar.current.component(.hour, from: arrivalDate)
+        return hour >= openingHour && hour < closingHour
+    }
+
+    func maxLeaveDate(closingHour: Int) -> Date {
+        Calendar.current.date(bySettingHour: closingHour, minute: 0, second: 0, of: arrivalDate)
+            ?? arrivalDate.addingTimeInterval(3600)
+    }
+
+    func validationError(openingHour: Int, closingHour: Int) -> String? {
+        let hour = Calendar.current.component(.hour, from: arrivalDate)
+        if hour < openingHour {
+            return "Parking opens at \(openingHour):00"
+        }
+        if hour >= closingHour {
+            return "Parking closes at \(closingHour):00"
+        }
+        if leaveDate <= arrivalDate {
+            return "Leave time must be after arrival"
+        }
+        let leaveHour = Calendar.current.component(.hour, from: leaveDate)
+        let leaveMinute = Calendar.current.component(.minute, from: leaveDate)
+        if leaveHour > closingHour || (leaveHour == closingHour && leaveMinute > 0) {
+            return "Parking closes at \(closingHour):00"
+        }
+        return nil
+    }
+
+    func clampLeaveDate(closingHour: Int) {
+        // Keep leave after arrival
+        if leaveDate <= arrivalDate {
+            leaveDate = arrivalDate.addingTimeInterval(3600)
+        }
+        // Cap at closing
+        let maxLeave = maxLeaveDate(closingHour: closingHour)
+        if leaveDate > maxLeave {
+            leaveDate = maxLeave
+        }
+    }
+
+    // MARK: - Cost
+
+    func estimatedCost() -> Double {
+        ParkingConfig.calculateFee(hours: durationHours, currentDayTotal: 0)
+    }
+
+    // MARK: - Calendar Export
+
+    func exportTrip(parkingName: String, closingHour: Int) async {
+        let status = store.authorizationStatus(for: .event)
+
+        switch status {
+        case .notDetermined:
+            do {
+                let granted = try await store.requestWriteOnlyAccessToEvents()
+                if granted {
+                    await saveTrip(parkingName: parkingName, closingHour: closingHour)
+                } else {
+                    await showDeniedAlert()
+                }
+            } catch {
+                await showErrorAlert(error)
+            }
+        case .writeOnly, .fullAccess, .authorized:
+            await saveTrip(parkingName: parkingName, closingHour: closingHour)
+        case .denied, .restricted:
+            await showDeniedAlert()
+        @unknown default:
+            await showDeniedAlert()
+        }
+    }
+
+    // MARK: - Private
+
+    private func saveTrip(parkingName: String, closingHour: Int) async {
+        let event = store.makeEvent()
+        event.title = "Planned Trip \u{2014} SD Building Parking"
+        event.location = "\(parkingName), Universidad de los Andes"
+        event.startDate = arrivalDate
+
+        let closingDate = Calendar.current.date(bySettingHour: closingHour, minute: 0, second: 0, of: arrivalDate) ?? leaveDate
+        event.endDate = min(leaveDate, closingDate)
+
+        let cost = estimatedCost()
+        event.notes = "Estimated cost: COP \(Int(cost))"
+
+        do {
+            try store.save(event, span: .thisEvent, commit: true)
+            await MainActor.run {
+                alertTitle = "Event Added"
+                alertMessage = "Your planned trip was added to Calendar."
+                showAlert = true
+                didExport = true
+            }
+        } catch {
+            await showErrorAlert(error)
+        }
+    }
+
+    private func showDeniedAlert() async {
+        await MainActor.run {
+            alertTitle = "Calendar Access Denied"
+            alertMessage = "Enable calendar access in Settings to export parking events."
+            showAlert = true
+        }
+    }
+
+    private func showErrorAlert(_ error: Error) async {
+        await MainActor.run {
+            alertTitle = "Error"
+            alertMessage = error.localizedDescription
+            showAlert = true
+        }
+    }
+}

--- a/sd-smart-parking/sd-smart-parking/Views/Usuario/ActiveInfo/VehicleStatus.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Usuario/ActiveInfo/VehicleStatus.swift
@@ -5,9 +5,13 @@
 //  Created by Mateo on 7/04/26.
 //
 import SwiftUI
+import EventKit
+
 struct VehicleStatusCard: View {
     let record: VehicleRecord
     let now: Date // Para el timer
+    @StateObject private var calendarVM = CalendarExportViewModel()
+    @EnvironmentObject var config: ParkingConfig
     
     var body: some View {
         VStack(alignment: .leading, spacing: 15) {
@@ -57,6 +61,19 @@ struct VehicleStatusCard: View {
                         .foregroundColor(.blue)
                 }
                 Spacer()
+                Button {
+                    Task {
+                        await calendarVM.exportEvent(
+                            record: record,
+                            parkingName: config.parkingName,
+                            closingHour: config.closingHour
+                        )
+                    }
+                } label: {
+                    Image(systemName: "calendar.badge.plus")
+                        .font(.title2)
+                        .foregroundColor(.blue)
+                }
                 Image(systemName: "creditcard.fill")
                     .font(.title2)
                     .foregroundColor(.secondary.opacity(0.5))
@@ -69,6 +86,11 @@ struct VehicleStatusCard: View {
         .background(Color(UIColor.secondarySystemGroupedBackground))
         .cornerRadius(20)
         .shadow(color: .black.opacity(0.05), radius: 10, x: 0, y: 5)
+        .alert(calendarVM.alertTitle, isPresented: $calendarVM.showAlert) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(calendarVM.alertMessage)
+        }
     }
     
     // Propiedades calculadas

--- a/sd-smart-parking/sd-smart-parking/Views/Usuario/Dashboard/DashboardView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Usuario/Dashboard/DashboardView.swift
@@ -13,6 +13,7 @@ struct DashboardView: View {
     @Binding var selectedTab: Int
     @Binding var scrollOffset: CGFloat
     @EnvironmentObject var authVM: AuthViewModel
+    @State private var showTripPlanner = false
     
     var body: some View {
         ZStack(alignment: .top) {
@@ -71,7 +72,8 @@ struct DashboardView: View {
                                 ParkingClosedCardView(
                                     opensAtHour: opensAt,
                                     now: now,
-                                    selectedTab: $selectedTab
+                                    selectedTab: $selectedTab,
+                                    showTripPlanner: $showTripPlanner
                                 )
                             default:
                                 availabilityCard
@@ -113,7 +115,11 @@ struct DashboardView: View {
                         )
             
             // 3. CAPA DEL HEADER (Siempre arriba en el ZStack)
-            
+
+        }
+        .sheet(isPresented: $showTripPlanner) {
+            TripPlannerSheetView()
+                .environmentObject(vm.config)
         }
     }
     
@@ -173,6 +179,18 @@ struct DashboardView: View {
 
                 Button(action: { withAnimation { selectedTab = 1 } }) {
                     Label("Spot View", systemImage: "calendar")
+                        .font(.headline)
+                        .foregroundColor(.blue)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(
+                            RoundedRectangle(cornerRadius: 12)
+                                .stroke(Color.blue, lineWidth: 2)
+                        )
+                }
+
+                Button(action: { showTripPlanner = true }) {
+                    Label("Plan Trip", systemImage: "calendar.badge.clock")
                         .font(.headline)
                         .foregroundColor(.blue)
                         .frame(maxWidth: .infinity)

--- a/sd-smart-parking/sd-smart-parking/Views/Usuario/Dashboard/ParkingClosedCardView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Usuario/Dashboard/ParkingClosedCardView.swift
@@ -9,6 +9,7 @@ struct ParkingClosedCardView: View {
     let opensAtHour: Int
     let now: Date
     @Binding var selectedTab: Int
+    @Binding var showTripPlanner: Bool
 
     private var opensTomorrow: Bool {
         let currentHour = Calendar.current.component(.hour, from: now)
@@ -86,6 +87,18 @@ struct ParkingClosedCardView: View {
                                 .stroke(Color.blue, lineWidth: 2)
                         )
                 }
+
+                Button(action: { showTripPlanner = true }) {
+                    Label("Plan Trip", systemImage: "calendar.badge.clock")
+                        .font(.headline)
+                        .foregroundColor(.orange)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(
+                            RoundedRectangle(cornerRadius: 12)
+                                .stroke(Color.orange, lineWidth: 2)
+                        )
+                }
             }
         }
         .padding(24)
@@ -97,5 +110,5 @@ struct ParkingClosedCardView: View {
 }
 
 #Preview("Opens Tomorrow") {
-    ParkingClosedCardView(opensAtHour: 6, now: Date(), selectedTab: .constant(0))
+    ParkingClosedCardView(opensAtHour: 6, now: Date(), selectedTab: .constant(0), showTripPlanner: .constant(false))
 }

--- a/sd-smart-parking/sd-smart-parking/Views/Usuario/Dashboard/TripPlannerSheetView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Usuario/Dashboard/TripPlannerSheetView.swift
@@ -1,0 +1,105 @@
+//
+//  TripPlannerSheetView.swift
+//  sd-smart-parking
+//
+
+import SwiftUI
+
+struct TripPlannerSheetView: View {
+    @StateObject private var tripVM = TripPlannerViewModel()
+    @EnvironmentObject var config: ParkingConfig
+    @Environment(\.dismiss) private var dismiss
+
+    private var validationError: String? {
+        tripVM.validationError(openingHour: config.openingHour, closingHour: config.closingHour)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Entry") {
+                    DatePicker(
+                        "Arrival",
+                        selection: $tripVM.arrivalDate,
+                        in: Date().addingTimeInterval(15 * 60)...,
+                        displayedComponents: [.date, .hourAndMinute]
+                    )
+
+                    if let error = validationError {
+                        Label(error, systemImage: "exclamationmark.triangle.fill")
+                            .font(.caption)
+                            .foregroundColor(.red)
+                    }
+                }
+
+                Section("Exit") {
+                    DatePicker(
+                        "Leave",
+                        selection: $tripVM.leaveDate,
+                        in: tripVM.arrivalDate.addingTimeInterval(1800)...tripVM.maxLeaveDate(closingHour: config.closingHour),
+                        displayedComponents: [.hourAndMinute]
+                    )
+
+                    Text("\(tripVM.durationHours, specifier: "%.1f") hours")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                Section("Estimated Cost") {
+                    HStack {
+                        Text("COP")
+                            .foregroundColor(.secondary)
+                        Text("\(Int(tripVM.estimatedCost()))")
+                            .font(.title2.bold())
+                            .foregroundColor(.blue)
+                    }
+
+                    if tripVM.isPeak {
+                        ParkingStatusBannerView(
+                            demandLevel: .peak,
+                            countdown: tripVM.arrivalCountdown(
+                                openingHour: config.openingHour,
+                                closingHour: config.closingHour
+                            )
+                        )
+                    }
+                }
+            }
+            .navigationTitle("Plan Trip")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Add to Calendar") {
+                        Task {
+                            await tripVM.exportTrip(
+                                parkingName: config.parkingName,
+                                closingHour: config.closingHour
+                            )
+                        }
+                    }
+                    .disabled(validationError != nil)
+                }
+            }
+            .alert(tripVM.alertTitle, isPresented: $tripVM.showAlert) {
+                Button("OK", role: .cancel) {
+                    if tripVM.didExport {
+                        dismiss()
+                    }
+                }
+            } message: {
+                Text(tripVM.alertMessage)
+            }
+            .onChange(of: tripVM.arrivalDate) {
+                tripVM.clampLeaveDate(closingHour: config.closingHour)
+            }
+        }
+    }
+}
+
+#Preview {
+    TripPlannerSheetView()
+        .environmentObject(ParkingConfig())
+}

--- a/sd-smart-parking/sd-smart-parkingTests/CalendarExportViewModelTests.swift
+++ b/sd-smart-parking/sd-smart-parkingTests/CalendarExportViewModelTests.swift
@@ -1,0 +1,132 @@
+//
+//  CalendarExportViewModelTests.swift
+//  sd-smart-parkingTests
+//
+
+import EventKit
+import Foundation
+import Testing
+@testable import sd_smart_parking
+
+// MARK: - Mock
+
+private class MockCalendarEventStore: CalendarEventStoring {
+    var statusToReturn: EKAuthorizationStatus = .notDetermined
+    var requestAccessResult = true
+    var requestAccessError: Error?
+    var savedEvent: EKEvent?
+    var saveError: Error?
+
+    func authorizationStatus(for entityType: EKEntityType) -> EKAuthorizationStatus {
+        statusToReturn
+    }
+
+    func requestWriteOnlyAccessToEvents() async throws -> Bool {
+        if let error = requestAccessError { throw error }
+        return requestAccessResult
+    }
+
+    func save(_ event: EKEvent, span: EKSpan, commit: Bool) throws {
+        if let error = saveError { throw error }
+        savedEvent = event
+    }
+
+    func makeEvent() -> EKEvent {
+        EKEvent(eventStore: EKEventStore())
+    }
+}
+
+// MARK: - Tests
+
+@Suite("CalendarExportViewModel")
+struct CalendarExportTests {
+
+    private func makeRecord(plate: String = "ABC123", timestamp: Date = Date()) -> VehicleRecord {
+        VehicleRecord(
+            plate: plate,
+            type: .entry,
+            timestamp: timestamp,
+            floor: 2,
+            spotNumber: 5,
+            photoURL: nil,
+            isRegistered: true,
+            ownerEmail: "test@uniandes.edu.co",
+            ocrConfidence: 1.0
+        )
+    }
+
+    @Test func exportEvent_whenAccessGranted_savesCorrectEvent() async {
+        let mock = MockCalendarEventStore()
+        mock.statusToReturn = .notDetermined
+        mock.requestAccessResult = true
+        let vm = CalendarExportViewModel(store: mock)
+        let record = makeRecord(plate: "XYZ789")
+
+        await vm.exportEvent(record: record, parkingName: "SD Building Parking", closingHour: 22)
+
+        #expect(mock.savedEvent != nil)
+        #expect(mock.savedEvent?.title?.contains("XYZ789") == true)
+        #expect(mock.savedEvent?.location?.contains("SD Building Parking") == true)
+        let delta = abs(mock.savedEvent!.startDate.timeIntervalSince(record.timestamp))
+        #expect(delta < 1.0)
+        #expect(vm.alertTitle == "Event Added")
+    }
+
+    @Test func exportEvent_whenAccessDenied_showsDenialAlert() async {
+        let mock = MockCalendarEventStore()
+        mock.statusToReturn = .notDetermined
+        mock.requestAccessResult = false
+        let vm = CalendarExportViewModel(store: mock)
+
+        await vm.exportEvent(record: makeRecord(), parkingName: "SD", closingHour: 22)
+
+        #expect(mock.savedEvent == nil)
+        #expect(vm.alertTitle == "Calendar Access Denied")
+    }
+
+    @Test func exportEvent_whenSaveThrows_showsErrorAlert() async {
+        let mock = MockCalendarEventStore()
+        mock.statusToReturn = .writeOnly
+        mock.saveError = NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "Save failed"])
+        let vm = CalendarExportViewModel(store: mock)
+
+        await vm.exportEvent(record: makeRecord(), parkingName: "SD", closingHour: 22)
+
+        #expect(vm.alertTitle == "Error")
+        #expect(vm.alertMessage.contains("Save failed"))
+    }
+
+    @Test func exportEvent_endTime_cappedAtClosingHour() async {
+        let mock = MockCalendarEventStore()
+        mock.statusToReturn = .writeOnly
+        let vm = CalendarExportViewModel(store: mock)
+
+        // 21:00 + 2h = 23:00, but closing is 22:00 → end should be 22:00
+        var comps = Calendar.current.dateComponents([.year, .month, .day], from: Date())
+        comps.hour = 21; comps.minute = 0; comps.second = 0
+        let late = Calendar.current.date(from: comps)!
+        let record = makeRecord(timestamp: late)
+
+        await vm.exportEvent(record: record, parkingName: "SD", closingHour: 22)
+
+        let expectedEnd = Calendar.current.date(bySettingHour: 22, minute: 0, second: 0, of: late)!
+        #expect(mock.savedEvent?.endDate == expectedEnd)
+    }
+
+    @Test func exportEvent_endTime_usesDefault2Hours() async {
+        let mock = MockCalendarEventStore()
+        mock.statusToReturn = .writeOnly
+        let vm = CalendarExportViewModel(store: mock)
+
+        // 10:00 + 2h = 12:00, closing at 22:00 → end should be 12:00
+        var comps = Calendar.current.dateComponents([.year, .month, .day], from: Date())
+        comps.hour = 10; comps.minute = 0; comps.second = 0
+        let morning = Calendar.current.date(from: comps)!
+        let record = makeRecord(timestamp: morning)
+
+        await vm.exportEvent(record: record, parkingName: "SD", closingHour: 22)
+
+        let expectedEnd = morning.addingTimeInterval(2 * 3600)
+        #expect(mock.savedEvent?.endDate == expectedEnd)
+    }
+}

--- a/sd-smart-parking/sd-smart-parkingTests/TripPlannerViewModelTests.swift
+++ b/sd-smart-parking/sd-smart-parkingTests/TripPlannerViewModelTests.swift
@@ -1,0 +1,193 @@
+//
+//  TripPlannerViewModelTests.swift
+//  sd-smart-parkingTests
+//
+
+import EventKit
+import Foundation
+import Testing
+@testable import sd_smart_parking
+
+// MARK: - Mock
+
+private class MockCalendarStore: CalendarEventStoring {
+    var statusToReturn: EKAuthorizationStatus = .writeOnly
+    var requestAccessResult = true
+    var requestAccessError: Error?
+    var savedEvent: EKEvent?
+    var saveError: Error?
+
+    func authorizationStatus(for entityType: EKEntityType) -> EKAuthorizationStatus {
+        statusToReturn
+    }
+
+    func requestWriteOnlyAccessToEvents() async throws -> Bool {
+        if let error = requestAccessError { throw error }
+        return requestAccessResult
+    }
+
+    func save(_ event: EKEvent, span: EKSpan, commit: Bool) throws {
+        if let error = saveError { throw error }
+        savedEvent = event
+    }
+
+    func makeEvent() -> EKEvent {
+        EKEvent(eventStore: EKEventStore())
+    }
+}
+
+// MARK: - Helpers
+
+private func makeDate(hour: Int, minute: Int = 0, weekday: Int? = nil) -> Date {
+    var comps = Calendar.current.dateComponents([.year, .month, .day], from: Date())
+    comps.hour = hour
+    comps.minute = minute
+    comps.second = 0
+
+    var date = Calendar.current.date(from: comps)!
+
+    if let weekday {
+        let current = Calendar.current.component(.weekday, from: date)
+        let daysToAdd = (weekday - current + 7) % 7
+        if daysToAdd > 0 {
+            date = Calendar.current.date(byAdding: .day, value: daysToAdd, to: date)!
+        }
+    }
+    return date
+}
+
+// MARK: - Cost Estimation
+
+@Suite("TripPlannerCostEstimation")
+struct TripPlannerCostTests {
+
+    @Test func cost_1hour_returns2000() {
+        let vm = TripPlannerViewModel(store: MockCalendarStore())
+        vm.arrivalDate = makeDate(hour: 10)
+        vm.leaveDate = makeDate(hour: 11)
+        #expect(vm.estimatedCost() == 2000)
+    }
+
+    @Test func cost_halfHour_returns1000() {
+        let vm = TripPlannerViewModel(store: MockCalendarStore())
+        vm.arrivalDate = makeDate(hour: 10)
+        vm.leaveDate = makeDate(hour: 10, minute: 30)
+        #expect(vm.estimatedCost() == 1000)
+    }
+
+    @Test func cost_8hours_cappedAtDailyCap() {
+        let vm = TripPlannerViewModel(store: MockCalendarStore())
+        vm.arrivalDate = makeDate(hour: 10)
+        vm.leaveDate = makeDate(hour: 18)
+        #expect(vm.estimatedCost() == 16000)
+    }
+}
+
+// MARK: - Validation
+
+@Suite("TripPlannerValidation")
+struct TripPlannerValidationTests {
+
+    @Test func arrivalAt3AM_isInvalid() {
+        let vm = TripPlannerViewModel(store: MockCalendarStore())
+        vm.arrivalDate = makeDate(hour: 3)
+        #expect(!vm.isArrivalValid(openingHour: 6, closingHour: 22))
+        #expect(vm.validationError(openingHour: 6, closingHour: 22) != nil)
+    }
+
+    @Test func arrivalAt22_isInvalid() {
+        let vm = TripPlannerViewModel(store: MockCalendarStore())
+        vm.arrivalDate = makeDate(hour: 22)
+        #expect(!vm.isArrivalValid(openingHour: 6, closingHour: 22))
+    }
+
+    @Test func arrivalAt10AM_isValid() {
+        let vm = TripPlannerViewModel(store: MockCalendarStore())
+        vm.arrivalDate = makeDate(hour: 10)
+        vm.leaveDate = makeDate(hour: 12)
+        #expect(vm.isArrivalValid(openingHour: 6, closingHour: 22))
+        #expect(vm.validationError(openingHour: 6, closingHour: 22) == nil)
+    }
+
+    @Test func leaveBeforeArrival_isInvalid() {
+        let vm = TripPlannerViewModel(store: MockCalendarStore())
+        vm.arrivalDate = makeDate(hour: 14)
+        vm.leaveDate = makeDate(hour: 12)
+        #expect(vm.validationError(openingHour: 6, closingHour: 22) != nil)
+    }
+
+    @Test func clampLeaveDate_capsAtClosing() {
+        let vm = TripPlannerViewModel(store: MockCalendarStore())
+        vm.arrivalDate = makeDate(hour: 20)
+        vm.leaveDate = makeDate(hour: 23) // past closing
+        vm.clampLeaveDate(closingHour: 22)
+        let leaveHour = Calendar.current.component(.hour, from: vm.leaveDate)
+        #expect(leaveHour <= 22)
+    }
+
+    @Test func clampLeaveDate_pushesAfterArrival() {
+        let vm = TripPlannerViewModel(store: MockCalendarStore())
+        vm.arrivalDate = makeDate(hour: 15)
+        vm.leaveDate = makeDate(hour: 14) // before arrival
+        vm.clampLeaveDate(closingHour: 22)
+        #expect(vm.leaveDate > vm.arrivalDate)
+    }
+}
+
+// MARK: - Peak Detection
+
+@Suite("TripPlannerPeakDetection")
+struct TripPlannerPeakTests {
+
+    @Test func weekdayAt7AM_isPeak() {
+        let vm = TripPlannerViewModel(store: MockCalendarStore())
+        vm.arrivalDate = makeDate(hour: 7, weekday: 2)
+        #expect(vm.isPeak)
+    }
+
+    @Test func weekdayAt10AM_isNotPeak() {
+        let vm = TripPlannerViewModel(store: MockCalendarStore())
+        vm.arrivalDate = makeDate(hour: 10, weekday: 2)
+        #expect(!vm.isPeak)
+    }
+
+    @Test func weekendAt8AM_isNotPeak() {
+        let vm = TripPlannerViewModel(store: MockCalendarStore())
+        vm.arrivalDate = makeDate(hour: 8, weekday: 7)
+        #expect(!vm.isPeak)
+    }
+}
+
+// MARK: - Calendar Export
+
+@Suite("TripPlannerCalendarExport")
+struct TripPlannerExportTests {
+
+    @Test func exportTrip_savesCorrectEvent() async {
+        let mock = MockCalendarStore()
+        mock.statusToReturn = .writeOnly
+        let vm = TripPlannerViewModel(store: mock)
+        vm.arrivalDate = makeDate(hour: 10)
+        vm.leaveDate = makeDate(hour: 12)
+
+        await vm.exportTrip(parkingName: "SD Building Parking", closingHour: 22)
+
+        #expect(mock.savedEvent != nil)
+        #expect(mock.savedEvent?.title?.contains("Planned Trip") == true)
+        #expect(mock.savedEvent?.location?.contains("SD Building Parking") == true)
+        #expect(mock.savedEvent?.notes?.contains("COP") == true)
+        #expect(vm.alertTitle == "Event Added")
+        #expect(vm.didExport)
+    }
+
+    @Test func exportTrip_denied_showsAlert() async {
+        let mock = MockCalendarStore()
+        mock.statusToReturn = .denied
+        let vm = TripPlannerViewModel(store: mock)
+
+        await vm.exportTrip(parkingName: "SD", closingHour: 22)
+
+        #expect(mock.savedEvent == nil)
+        #expect(vm.alertTitle == "Calendar Access Denied")
+    }
+}


### PR DESCRIPTION
## Summary

- **Calendar export for active sessions:** Adds a calendar button (`calendar.badge.plus`) to `VehicleStatusCard` that creates an EKEvent with parking details (plate, floor, spot, start/end time) via write-only EventKit access.
- **Trip planner for future visits:** Adds a "Plan Trip" button on the Dashboard (blue when open, orange when closed) that opens a sheet where drivers pick arrival and leave times. Shows estimated cost (via `ParkingConfig.calculateFee`), validates against operating hours, and displays a peak-hour warning banner when arrival falls in peak hours. Exports the plan to Calendar.
- **19 new tests:** 5 for `CalendarExportViewModel` (permission flow, event fields, end-time capping) + 14 for `TripPlannerViewModel` (cost estimation, time validation, peak detection, calendar export).

## Files changed

| File | Change |
|------|--------|
| `Info.plist` | Added `NSCalendarsWriteOnlyAccessUsageDescription` |
| `CalendarExportViewModel.swift` | New — EventKit wrapper with `CalendarEventStoring` protocol |
| `TripPlannerViewModel.swift` | New — validation, cost, peak detection, calendar export |
| `TripPlannerSheetView.swift` | New — form with entry/exit DatePickers, cost display, peak banner |
| `VehicleStatus.swift` | Added calendar button + alert for active sessions |
| `DashboardView.swift` | Added Plan Trip button + sheet |
| `ParkingClosedCardView.swift` | Added Plan Trip button (orange) |
| `CalendarExportViewModelTests.swift` | New — 5 tests |
| `TripPlannerViewModelTests.swift` | New — 14 tests |

## Test plan

- [x] `build_sim` passes
- [x] `test_sim` passes — 84/84 tests (19 new)
- [x] Manual: active session → tap calendar icon → allow permission → verify event in Calendar app
- [x] Manual: Dashboard → Plan Trip → pick peak hour arrival → see orange banner → Add to Calendar → verify event
- [ ] Manual: Dashboard (parking closed) → orange Plan Trip button → plan future trip

<!-- TODO: link issue -->