### PR TITLE
💄 fix(ui): force light theme and add scroll to login view

### DIFF
--- a/sd-smart-parking/sd-smart-parking/Views/Login/LoginView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Login/LoginView.swift
@@ -22,8 +22,8 @@ struct LoginView: View {
 
     var body: some View {
         NavigationStack {
+            ScrollView {
             VStack(spacing: 30) {
-                Spacer()
 
                 // MARK: - Logo/Header
                 VStack(spacing: 10) {
@@ -186,36 +186,38 @@ struct LoginView: View {
                     .foregroundColor(.blue)
                 }
                 .padding(.bottom, 20)
+
+                #if DEBUG
+                VStack(spacing: 12) {
+                    Text("Dev Tools")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+
+                    HStack(spacing: 12) {
+                        Button("Login as User") { authVM.loginAsUser() }
+                            .font(.caption)
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 8)
+                            .background(Color.blue.opacity(0.1))
+                            .foregroundColor(.blue)
+                            .cornerRadius(8)
+
+                        Button("Login as Manager") { authVM.loginAsGerente() }
+                            .font(.caption)
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 8)
+                            .background(Color.orange.opacity(0.1))
+                            .foregroundColor(.orange)
+                            .cornerRadius(8)
+                    }
+                }
+                .padding(.top, 20)
+                #endif
+            }
+            .padding(.top, 40)
             }
             .navigationBarHidden(true)
         }
-
-        #if DEBUG
-        VStack(spacing: 12) {
-            Text("Dev Tools")
-                .font(.caption)
-                .foregroundColor(.secondary)
-
-            HStack(spacing: 12) {
-                Button("Login as User") { authVM.loginAsUser() }
-                    .font(.caption)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 8)
-                    .background(Color.blue.opacity(0.1))
-                    .foregroundColor(.blue)
-                    .cornerRadius(8)
-
-                Button("Login as Manager") { authVM.loginAsGerente() }
-                    .font(.caption)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 8)
-                    .background(Color.orange.opacity(0.1))
-                    .foregroundColor(.orange)
-                    .cornerRadius(8)
-            }
-        }
-        .padding(.top, 20)
-        #endif
     }
 }
 

--- a/sd-smart-parking/sd-smart-parking/sd_smart_parkingApp.swift
+++ b/sd-smart-parking/sd-smart-parking/sd_smart_parkingApp.swift
@@ -27,6 +27,7 @@ struct sd_smart_parkingApp: App {
         WindowGroup {
             ContentView()
                 .environmentObject(navigationManager)
+                .preferredColorScheme(.light)
         }
     }
 }


### PR DESCRIPTION
## Summary

- Forces light color scheme app-wide via `.preferredColorScheme(.light)` on the root `ContentView`.
- Wraps the login form in a `ScrollView` so all content (email, password, login button, social sign-in buttons, biometric button, registration link, dev tools) is reachable on smaller screens.
- Removes the top `Spacer()` (incompatible with `ScrollView`) and replaces it with `.padding(.top, 40)`.
- Moves the `#if DEBUG` dev tools block inside the scroll area.

## Test plan

- [x] Launch app — verify light theme is always used regardless of system dark/light setting.
- [x] Open login view on a small device (iPhone SE) — verify all buttons and the registration link are reachable by scrolling.
- [x] Verify login, Google sign-in, Microsoft sign-in, and biometric buttons still function correctly.

<!-- TODO: link issue -->