### PR TITLE
🌐 fix(ui): translate parking status banners to English

### DIFF
--- a/sd-smart-parking/sd-smart-parking/Models/ParkingTimeStatus.swift
+++ b/sd-smart-parking/sd-smart-parking/Models/ParkingTimeStatus.swift
@@ -97,23 +97,23 @@ struct PeakHoursSchedule {
             if let range = peaks.first(where: { hour >= $0.start && hour < $0.end }) {
                 let endMinutes = range.end * 60
                 if endMinutes >= closingMinutes {
-                    return formatCountdown(closingMinutes - currentMinutes, suffix: "para cierre")
+                    return formatCountdown(closingMinutes - currentMinutes, suffix: "until closing")
                 }
-                return formatCountdown(endMinutes - currentMinutes, suffix: "para horario normal")
+                return formatCountdown(endMinutes - currentMinutes, suffix: "until normal hours")
             }
         case .valley:
             if let range = valleys.first(where: { hour >= $0.start && hour < $0.end }) {
                 let endMinutes = range.end * 60
                 if endMinutes >= closingMinutes {
-                    return formatCountdown(closingMinutes - currentMinutes, suffix: "para cierre")
+                    return formatCountdown(closingMinutes - currentMinutes, suffix: "until closing")
                 }
-                return formatCountdown(endMinutes - currentMinutes, suffix: "para horario normal")
+                return formatCountdown(endMinutes - currentMinutes, suffix: "until normal hours")
             }
         case .normal:
             var nextEvents: [(minuteMark: Int, label: String)] = []
-            for range in peaks { nextEvents.append((range.start * 60, "horas pico")) }
-            for range in valleys { nextEvents.append((range.start * 60, "horas valle")) }
-            nextEvents.append((closingMinutes, "cierre"))
+            for range in peaks { nextEvents.append((range.start * 60, "peak hours")) }
+            for range in valleys { nextEvents.append((range.start * 60, "off-peak hours")) }
+            nextEvents.append((closingMinutes, "closing"))
 
             if let next = nextEvents
                 .filter({ $0.minuteMark > currentMinutes })

--- a/sd-smart-parking/sd-smart-parking/Views/Components/ParkingStatusBannerView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Components/ParkingStatusBannerView.swift
@@ -19,9 +19,9 @@ struct ParkingStatusBannerView: View {
 
     private var label: String {
         switch demandLevel {
-        case .peak:   return "Horas Pico"
-        case .valley: return "Horas Valle"
-        case .normal: return "Horario Normal"
+        case .peak:   return "Peak Hours"
+        case .valley: return "Off-Peak Hours"
+        case .normal: return "Normal Hours"
         }
     }
 
@@ -71,7 +71,7 @@ struct ClosingSoonBannerView: View {
         HStack(spacing: 8) {
             Image(systemName: "exclamationmark.triangle.fill")
                 .foregroundColor(.red)
-            Text("Cierra en \(minutesLeft) min — planifica tu salida")
+            Text("Closes in \(minutesLeft) min — plan your exit")
                 .font(.system(size: 14, weight: .semibold))
                 .foregroundColor(.red)
             Spacer()
@@ -84,17 +84,17 @@ struct ClosingSoonBannerView: View {
 }
 
 #Preview("Peak") {
-    ParkingStatusBannerView(demandLevel: .peak, countdown: "1h 30m para horario normal")
+    ParkingStatusBannerView(demandLevel: .peak, countdown: "1h 30m until normal hours")
         .padding()
 }
 
 #Preview("Valley") {
-    ParkingStatusBannerView(demandLevel: .valley, countdown: "2h 0m para cierre")
+    ParkingStatusBannerView(demandLevel: .valley, countdown: "2h 0m until closing")
         .padding()
 }
 
 #Preview("Normal") {
-    ParkingStatusBannerView(demandLevel: .normal, countdown: "45 min para horas pico")
+    ParkingStatusBannerView(demandLevel: .normal, countdown: "45 min until peak hours")
         .padding()
 }
 

--- a/sd-smart-parking/sd-smart-parking/Views/Usuario/Dashboard/ParkingClosedCardView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Usuario/Dashboard/ParkingClosedCardView.swift
@@ -18,9 +18,9 @@ struct ParkingClosedCardView: View {
 
     private var opensLabel: String {
         if opensTomorrow {
-            return "Abre mañana a las \(opensAtHour):00"
+            return "Opens tomorrow at \(opensAtHour):00"
         }
-        return "Abre hoy a las \(opensAtHour):00"
+        return "Opens today at \(opensAtHour):00"
     }
 
     private var countdown: String {
@@ -39,9 +39,9 @@ struct ParkingClosedCardView: View {
         let mins = minutesUntilOpen % 60
 
         if hours > 0 {
-            return "Abre en \(hours)h \(mins)m"
+            return "Opens in \(hours)h \(mins)m"
         }
-        return "Abre en \(mins)m"
+        return "Opens in \(mins)m"
     }
 
     var body: some View {
@@ -50,7 +50,7 @@ struct ParkingClosedCardView: View {
                 .font(.system(size: 48))
                 .foregroundColor(.gray)
 
-            Text("Estacionamiento Cerrado")
+            Text("Parking Closed")
                 .font(.system(size: 24, weight: .bold))
 
             Text(opensLabel)

--- a/sd-smart-parking/sd-smart-parkingTests/ParkingTimeStatusTests.swift
+++ b/sd-smart-parking/sd-smart-parkingTests/ParkingTimeStatusTests.swift
@@ -188,35 +188,35 @@ struct TransitionCountdownTests {
         let result = PeakHoursSchedule.transitionCountdown(
             at: makeDate(hour: 7, minute: 30), openingHour: 6, closingHour: 22
         )
-        #expect(result == "1h 30m para horario normal")
+        #expect(result == "1h 30m until normal hours")
     }
 
     @Test func valleyShowsCountdownToNormal() {
         let result = PeakHoursSchedule.transitionCountdown(
             at: makeDate(hour: 13), openingHour: 6, closingHour: 22
         )
-        #expect(result == "2h 0m para horario normal")
+        #expect(result == "2h 0m until normal hours")
     }
 
     @Test func normalShowsNextValley() {
         let result = PeakHoursSchedule.transitionCountdown(
             at: makeDate(hour: 10), openingHour: 6, closingHour: 22
         )
-        #expect(result == "2h 0m para horas valle")
+        #expect(result == "2h 0m until off-peak hours")
     }
 
     @Test func normalShowsClosingWhenNoMoreTransitions() {
         let result = PeakHoursSchedule.transitionCountdown(
             at: makeDate(hour: 16), openingHour: 6, closingHour: 22
         )
-        #expect(result == "6h 0m para cierre")
+        #expect(result == "6h 0m until closing")
     }
 
     @Test func weekendValleyShowsClosingCountdown() {
         let result = PeakHoursSchedule.transitionCountdown(
             at: makeWeekendDate(hour: 10), openingHour: 6, closingHour: 22
         )
-        #expect(result == "12h 0m para cierre")
+        #expect(result == "12h 0m until closing")
     }
 
     @Test func closedReturnsNil() {


### PR DESCRIPTION
## Summary

Translates all Spanish-language strings in the time-aware parking status banners to English:

- **ParkingTimeStatus.swift**: countdown suffixes (`para cierre` → `until closing`, `horas pico` → `peak hours`, etc.)
- **ParkingStatusBannerView.swift**: banner labels (`Horas Pico` → `Peak Hours`, `Horas Valle` → `Off-Peak Hours`, etc.) and closing-soon text
- **ParkingClosedCardView.swift**: closed-state card (`Estacionamiento Cerrado` → `Parking Closed`, `Abre en` → `Opens in`, etc.)
- **ParkingTimeStatusTests.swift**: updated test assertions to match new English strings

## Test plan

- [x] Build succeeds on simulator
- [x] Open the dashboard during operating hours — banner shows "Peak Hours", "Off-Peak Hours", or "Normal Hours" with English countdown
- [x] Open the dashboard when parking is closing soon — banner shows "Closes in X min — plan your exit"
- [x] Open the dashboard when parking is closed — card shows "Parking Closed" with English open time

<!-- TODO: link issue -->