### PR TITLE
fix: add missing showHistory state and remove spurious await

### DIFF
--- a/sd-smart-parking/sd-smart-parking/Views/Gerente/RecordDetailView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Gerente/RecordDetailView.swift
@@ -97,7 +97,7 @@ struct RecordDetailView: View {
                                 // VEHÍCULO ADENTRO: BOTÓN ROJO DE ACCIÓN
                                 Button(action: {
                                     Task {
-                                        await registerExit()
+                                        registerExit()
                                         // Actualizamos el estado local para cambiar el color
                                         withAnimation {
                                             isInParking = false

--- a/sd-smart-parking/sd-smart-parking/Views/Usuario/Dashboard/DashboardView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Usuario/Dashboard/DashboardView.swift
@@ -14,6 +14,7 @@ struct DashboardView: View {
     @Binding var scrollOffset: CGFloat
     @EnvironmentObject var authVM: AuthViewModel
     @State private var showTripPlanner = false
+    @State private var showHistory = false
     
     var body: some View {
         ZStack(alignment: .top) {


### PR DESCRIPTION
## Summary

- **DashboardView**: declared the missing `@State private var showHistory = false` — it was referenced by the "My History" button and `.sheet(isPresented: $showHistory)` but never declared, causing a build failure
- **RecordDetailView**: removed `await` from `registerExit()` call since the function is not `async`, silencing a compiler warning

## Test plan

- [ ] Build succeeds with zero errors and zero warnings
- [ ] Tap "My History" card on the Dashboard — history sheet opens correctly
- [ ] Tap the exit button in a vehicle record — exit registers without issues