### PR TITLE
✨ feat(ios): personalize floor recommendation with user preferences

### DIFF
--- a/sd-smart-parking/sd-smart-parking/FileManagers/PendingAction.swift
+++ b/sd-smart-parking/sd-smart-parking/FileManagers/PendingAction.swift
@@ -10,6 +10,7 @@ enum ActionType: String, Codable {
     case addCar
     case occupySpace
     case updateProfile
+    case updatePreferences
 }
 
 struct PendingAction: Identifiable, Codable {

--- a/sd-smart-parking/sd-smart-parking/Models/PersonalizedRecommendation.swift
+++ b/sd-smart-parking/sd-smart-parking/Models/PersonalizedRecommendation.swift
@@ -1,0 +1,26 @@
+//
+//  PersonalizedRecommendation.swift
+//  sd-smart-parking
+//
+
+import Foundation
+
+/// Result returned by `ParkingViewModel.personalizedRecommendation(for:)`.
+/// Carries the floor pick, an optional spot to highlight, and the reason
+/// the recommendation was chosen so the UI can explain itself.
+struct PersonalizedRecommendation {
+    enum Reason: Equatable {
+        /// Driver has a mobility limitation — pick the lowest floor with availability.
+        case mobility
+        /// Driver picked this floor and it has availability.
+        case preferredFloor
+        /// Driver picked a floor but it's full; we recommend `fallback` instead.
+        case preferredFloorFull(fallback: Int)
+        /// No preferences set; behaves like the original recommendation engine.
+        case generic
+    }
+
+    let floor: Int
+    let spot: ParkingSpot?
+    let reason: Reason
+}

--- a/sd-smart-parking/sd-smart-parking/Models/User.swift
+++ b/sd-smart-parking/sd-smart-parking/Models/User.swift
@@ -17,12 +17,14 @@ struct User: Identifiable, Codable{
 
     //var cars: [Car]
 
-    
+    var preferences: UserPreferences?
+
+
     // Extrae todas las placas del usuario para la consulta
         var allPlates: [String] {
             //cars.map { $0.normalizedPlate }
             cars.allValues().map { $0.normalizedPlate }
         }
-    
-    
+
+
 }

--- a/sd-smart-parking/sd-smart-parking/Models/UserPreferences.swift
+++ b/sd-smart-parking/sd-smart-parking/Models/UserPreferences.swift
@@ -1,0 +1,31 @@
+//
+//  UserPreferences.swift
+//  sd-smart-parking
+//
+
+import Foundation
+
+/// Driver-declared context that personalizes the floor recommendation.
+struct UserPreferences: Codable, Equatable {
+    var hasMobilityLimitation: Bool
+    var preferredFloor: Int?
+
+    init(hasMobilityLimitation: Bool = false, preferredFloor: Int? = nil) {
+        self.hasMobilityLimitation = hasMobilityLimitation
+        self.preferredFloor = preferredFloor
+    }
+
+    func toFirestore() -> [String: Any] {
+        var dict: [String: Any] = [
+            "hasMobilityLimitation": hasMobilityLimitation
+        ]
+        if let preferredFloor { dict["preferredFloor"] = preferredFloor }
+        return dict
+    }
+
+    init?(firestore data: [String: Any]?) {
+        guard let data else { return nil }
+        self.hasMobilityLimitation = data["hasMobilityLimitation"] as? Bool ?? false
+        self.preferredFloor = data["preferredFloor"] as? Int
+    }
+}

--- a/sd-smart-parking/sd-smart-parking/Repositories/UserRepository.swift
+++ b/sd-smart-parking/sd-smart-parking/Repositories/UserRepository.swift
@@ -71,8 +71,8 @@ class UserRepository: ObservableObject {
     // MÉTODO: ACTUALIZAR PERFIL (Llamado desde el ViewModel)
     func updateProfile(newName: String, newEmail: String) {
         guard var user = currentUser else { return }
-        user = User(id: user.id, name: newName, email: newEmail, password: "", cars: user.cars)
-        
+        user = User(id: user.id, name: newName, email: newEmail, password: "", cars: user.cars, preferences: user.preferences)
+
         // 1. Local
         self.currentUser = user
         diskManager.save(user, to: profileFileName)
@@ -83,6 +83,23 @@ class UserRepository: ObservableObject {
         } else {
             // Aquí podrías crear un struct "ProfileUpdate" para el payload
             saveActionToQueue(action: .updateProfile, data: ["name": newName, "email": newEmail])
+        }
+    }
+
+    // MÉTODO: ACTUALIZAR PREFERENCIAS (mobility / preferred floor)
+    func updatePreferences(_ preferences: UserPreferences) {
+        guard var user = currentUser else { return }
+        user.preferences = preferences
+
+        // 1. Local
+        self.currentUser = user
+        diskManager.save(user, to: profileFileName)
+
+        // 2. Sincronización
+        if !isOffline {
+            Task { await uploadPreferencesToFirebase(preferences) }
+        } else {
+            saveActionToQueue(action: .updatePreferences, data: preferences)
         }
     }
 
@@ -123,6 +140,18 @@ class UserRepository: ObservableObject {
         ])
     }
 
+    private func uploadPreferencesToFirebase(_ preferences: UserPreferences) async {
+        guard let uid = Auth.auth().currentUser?.uid else { return }
+        do {
+            try await db.collection("users").document(uid).setData(
+                ["preferences": preferences.toFirestore()],
+                merge: true
+            )
+        } catch {
+            self.saveActionToQueue(action: .updatePreferences, data: preferences)
+        }
+    }
+
     // --- MOTOR DE SINCRONIZACIÓN ---
 
     func syncPendingActions() {
@@ -150,6 +179,11 @@ class UserRepository: ObservableObject {
         case .updateProfile:
             if let data = try? JSONDecoder().decode([String: String].self, from: action.payload) {
                 await uploadProfileToFirebase(newName: data["name"] ?? "", newEmail: data["email"] ?? "")
+                return true
+            }
+        case .updatePreferences:
+            if let prefs = try? JSONDecoder().decode(UserPreferences.self, from: action.payload) {
+                await uploadPreferencesToFirebase(prefs)
                 return true
             }
         default: return true

--- a/sd-smart-parking/sd-smart-parking/ViewModels/AuthViewModel.swift
+++ b/sd-smart-parking/sd-smart-parking/ViewModels/AuthViewModel.swift
@@ -106,8 +106,11 @@ class AuthViewModel: ObservableObject {
                 carsMap.put(car, for: car.normalizedPlate)
             }
             
+            // Preferencias personalizadas (puede no existir en el doc)
+            let preferences = UserPreferences(firestore: data["preferences"] as? [String: Any])
+
             // Creamos al User pasando el ArrayMap
-            let user = User(id: UUID(uuidString: uid) ?? UUID(), name: name, email: email, password: "", cars: carsMap)
+            let user = User(id: UUID(uuidString: uid) ?? UUID(), name: name, email: email, password: "", cars: carsMap, preferences: preferences)
             
             await MainActor.run {
                 self.currentUser = user
@@ -392,7 +395,7 @@ class AuthViewModel: ObservableObject {
         mockCarsMap.put(car1, for: car1.normalizedPlate)
         mockCarsMap.put(car2, for: car2.normalizedPlate)
         
-        currentUser = User(id: UUID(), name: "Usuario Andes", email: "usuario@uniandes.edu.co", password: "", cars: mockCarsMap)
+        currentUser = User(id: UUID(), name: "Usuario Andes", email: "usuario@uniandes.edu.co", password: "", cars: mockCarsMap, preferences: nil)
         isLoggedIn = true
         isGerente = false
         currentUserEmail = "usuario@uniandes.edu.co"
@@ -400,7 +403,7 @@ class AuthViewModel: ObservableObject {
     
     func loginAsGerente() {
         // Para el gerente pasamos un ArrayMap vacío
-        currentUser = User(id: UUID(), name: "Gerente Andes", email: "gerente@uniandes.edu.co", password: "", cars: ArrayMap<String, Car>())
+        currentUser = User(id: UUID(), name: "Gerente Andes", email: "gerente@uniandes.edu.co", password: "", cars: ArrayMap<String, Car>(), preferences: nil)
         isLoggedIn = true
         isGerente = true
         currentUserEmail = "gerente@uniandes.edu.co"

--- a/sd-smart-parking/sd-smart-parking/ViewModels/ParkingViewModel.swift
+++ b/sd-smart-parking/sd-smart-parking/ViewModels/ParkingViewModel.swift
@@ -63,7 +63,78 @@ class ParkingViewModel: ObservableObject {
 
         return best.key
     }
- 
+
+    // MARK: - Personalized recommendation
+
+    /// Lowest-numbered available spot on a given floor (closest to elevator/stairs).
+    private func lowestAvailableSpot(onFloor floor: Int) -> ParkingSpot? {
+        spots
+            .filter { $0.floor == floor && $0.isAvailable }
+            .min { $0.number < $1.number }
+    }
+
+    /// Floor with availability that is closest to the building entrance —
+    /// modeled here as the lowest floor number that has any free spot.
+    /// Used for the mobility-aware path.
+    private var lowestFloorWithAvailability: Int? {
+        floorAvailability
+            .filter { $0.value.available > 0 }
+            .keys
+            .min()
+    }
+
+    /// Personalized floor + spot recommendation that respects user-declared
+    /// mobility limitations and a preferred floor.
+    ///
+    /// Priority order (preferred floor wins over mobility — rationale: this is
+    /// a university building where the preferred floor is usually the floor of
+    /// the user's class, so parking elsewhere defeats the point even for a
+    /// driver with a mobility limitation. The closest-to-elevator spot on the
+    /// preferred floor is still picked):
+    ///   1. Preferred floor with availability → that floor + closest-to-elevator spot
+    ///   2. Mobility limitation → lowest floor with availability + closest-to-elevator spot
+    ///      (used when no preferred floor is set, or when preferred floor is full)
+    ///   3. Generic `recommendedFloor` as final fallback
+    ///   4. `nil` when no recommendation is possible (all full / suppressed tie)
+    ///
+    /// Spot selection inside the chosen floor is always the lowest-numbered
+    /// available spot, which corresponds to the spot closest to the
+    /// elevator/stairs core in the production numbering scheme.
+    func personalizedRecommendation(for prefs: UserPreferences?) -> PersonalizedRecommendation? {
+        // 1. Preferred floor wins when it has availability.
+        if let preferred = prefs?.preferredFloor,
+           let avail = floorAvailability[preferred],
+           avail.available > 0 {
+            return PersonalizedRecommendation(
+                floor: preferred,
+                spot: lowestAvailableSpot(onFloor: preferred),
+                reason: .preferredFloor
+            )
+        }
+
+        // Preferred floor was set but has no availability — flag it for the UI
+        // copy so the fallback can be explained.
+        let preferredIsFull = prefs?.preferredFloor.flatMap { floorAvailability[$0]?.available } == 0
+
+        // 2. Mobility path (no preferred match): lowest floor with availability.
+        if prefs?.hasMobilityLimitation == true {
+            guard let floor = lowestFloorWithAvailability else { return nil }
+            return PersonalizedRecommendation(
+                floor: floor,
+                spot: lowestAvailableSpot(onFloor: floor),
+                reason: preferredIsFull ? .preferredFloorFull(fallback: floor) : .mobility
+            )
+        }
+
+        // 3. Generic recommendation (with optional "preferred floor full" hint).
+        guard let generic = recommendedFloor else { return nil }
+        return PersonalizedRecommendation(
+            floor: generic,
+            spot: lowestAvailableSpot(onFloor: generic),
+            reason: preferredIsFull ? .preferredFloorFull(fallback: generic) : .generic
+        )
+    }
+
     // MARK: - Init
  
     init() {

--- a/sd-smart-parking/sd-smart-parking/Views/Parking/SpotsView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Parking/SpotsView.swift
@@ -10,10 +10,12 @@ import SwiftUI
 struct SpotsView: View {
     @EnvironmentObject var vm: ParkingViewModel
     @EnvironmentObject var authVM: AuthViewModel
+    @EnvironmentObject var userRepo: UserRepository
 
     @State private var expandedFloors: Set<Int> = []
     @State private var pendingBulkFree          = false
     @State private var pendingBulkOccupy        = false
+    @State private var showPreferencesSheet    = false
 
     let columns = [
         GridItem(.flexible(), spacing: 15),
@@ -25,61 +27,47 @@ struct SpotsView: View {
         Dictionary(grouping: vm.spots, by: { $0.floor }).keys.sorted()
     }
 
+    /// Personalized recommendation for the current driver. `nil` for managers
+    /// or when no recommendation is possible (e.g. all spots full / suppressed tie).
+    private var personalized: PersonalizedRecommendation? {
+        guard !authVM.isGerente else { return nil }
+        return vm.personalizedRecommendation(for: userRepo.currentUser?.preferences)
+    }
+
     var body: some View {
         NavigationStack {
             ScrollView {
                 VStack(alignment: .leading, spacing: 25) {
-                    // Recommendation banner (driver only)
+                    // Hero invitation (driver only, no preferences yet).
+                    // Renders ABOVE the recommendation so it's the first thing
+                    // a fresh driver sees, regardless of whether a generic
+                    // recommendation can be computed.
                     if !authVM.isGerente,
-                       let recommended = vm.recommendedFloor {
-                        let avail = vm.floorAvailability[recommended]?.available ?? 0
-                        let floorSpots = vm.spots
-                            .filter { $0.floor == recommended && $0.isAvailable }
-                            .sorted { $0.number < $1.number }
-                            .prefix(3)
-
-                        VStack(alignment: .leading, spacing: 12) {
-                            HStack(spacing: 8) {
-                                Image(systemName: "sparkles")
-                                    .foregroundColor(.green)
-                                Text("Best floor: Floor \(recommended)")
-                                    .font(.headline)
-                                FloorBadge(isUrgent: avail <= 4)
-                                Spacer()
-                            }
-
-                            Text("\(avail) spots available")
-                                .font(.subheadline)
-                                .foregroundColor(.secondary)
-
-                            LazyVGrid(columns: columns, spacing: 15) {
-                                ForEach(Array(floorSpots)) { spot in
-                                    SpotCardView(spot: spot, isGerente: false)
-                                }
-                            }
-                        }
-                        .padding()
-                        .background(Color.green.opacity(0.05))
-                        .cornerRadius(16)
-                        .padding(.horizontal)
+                       userRepo.currentUser?.preferences == nil {
+                        preferencesHeroBanner()
                     }
 
-                    ForEach(sortedFloors, id: \.self) { floor in // <- usar aquí
+                    // Personalized recommendation banner (driver only).
+                    // Includes a low-key "Edit preferences" pill at the bottom
+                    // so a driver who already has preferences can tweak them.
+                    if let rec = personalized {
+                        recommendationBanner(rec)
+                    }
+
+                    ForEach(sortedFloors, id: \.self) { floor in
                         VStack(alignment: .leading, spacing: 15) {
                             HStack {
                                 Text("Floor \(floor)")
                                     .font(.headline)
                                     .foregroundColor(.secondary)
 
-                                if !authVM.isGerente,
-                                   let recommended = vm.recommendedFloor,
-                                   recommended == floor {
+                                if let rec = personalized, rec.floor == floor {
                                     let avail = vm.floorAvailability[floor]?.available ?? 0
                                     FloorBadge(isUrgent: avail <= 4)
                                 }
                             }
                             .padding(.horizontal)
-                            
+
                             LazyVGrid(columns: columns, spacing: 15) {
                                 ForEach(vm.spots.filter { $0.floor == floor }.sorted(by: { $0.number < $1.number })) { spot in
                                     SpotCardView(spot: spot, isGerente: authVM.isGerente)
@@ -111,6 +99,168 @@ struct SpotsView: View {
                 Button("Occupy All", role: .destructive) { vm.occupyAllSpots() }
                 Button("Cancel", role: .cancel) { }
             } message: { Text("All spots will be marked as occupied.") }
+            .sheet(isPresented: $showPreferencesSheet) {
+                EditProfileView()
+            }
+        }
+    }
+
+    // MARK: - Personalized banner
+
+    @ViewBuilder
+    private func recommendationBanner(_ rec: PersonalizedRecommendation) -> some View {
+        let avail = vm.floorAvailability[rec.floor]?.available ?? 0
+        let preview = vm.spots
+            .filter { $0.floor == rec.floor && $0.isAvailable }
+            .sorted { $0.number < $1.number }
+            .prefix(3)
+        let mobility = userRepo.currentUser?.preferences?.hasMobilityLimitation ?? false
+
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 8) {
+                Image(systemName: bannerIcon(rec.reason, mobility: mobility))
+                    .foregroundColor(bannerTint(rec.reason))
+                Text(bannerTitle(rec))
+                    .font(.headline)
+                FloorBadge(isUrgent: avail <= 4)
+                Spacer()
+            }
+
+            Text(bannerSubtitle(rec, available: avail, mobility: mobility))
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            LazyVGrid(columns: columns, spacing: 15) {
+                ForEach(Array(preview)) { spot in
+                    SpotCardView(spot: spot, isGerente: false)
+                }
+            }
+
+            // Low-key "Edit preferences" pill — always visible inside the
+            // recommendation banner so the driver can tweak prefs in-context.
+            // Hidden only when the driver has no prefs yet (the prominent
+            // standalone hero above is doing that job).
+            if userRepo.currentUser?.preferences != nil {
+                Button {
+                    showPreferencesSheet = true
+                } label: {
+                    Label("Edit preferences", systemImage: "slider.horizontal.3")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 8)
+                        .frame(maxWidth: .infinity)
+                        .background(Color.blue)
+                        .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding()
+        .background(bannerTint(rec.reason).opacity(0.06))
+        .cornerRadius(16)
+        .padding(.horizontal)
+    }
+
+    /// Standalone hero shown to drivers with no preferences set. Always renders
+    /// when `currentUser?.preferences == nil`, regardless of whether a generic
+    /// recommendation exists below it — the goal is to make personalization
+    /// the first thing a fresh driver notices on the Spots tab.
+    @ViewBuilder
+    private func preferencesHeroBanner() -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: "person.crop.circle.badge.questionmark")
+                    .font(.system(size: 28))
+                    .foregroundColor(.blue)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Personalize your spot")
+                        .font(.title3.bold())
+                    Text("Tell us your preferred floor or if you need a mobility-friendly spot — we'll tailor every recommendation to you.")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            Button {
+                showPreferencesSheet = true
+            } label: {
+                Label("Set my parking preferences", systemImage: "slider.horizontal.3")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 12)
+                    .frame(maxWidth: .infinity)
+                    .background(Color.blue)
+                    .clipShape(Capsule())
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(18)
+        .background(
+            LinearGradient(
+                colors: [Color.blue.opacity(0.14), Color.blue.opacity(0.06)],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 18)
+                .strokeBorder(Color.blue.opacity(0.25), lineWidth: 1)
+        )
+        .cornerRadius(18)
+        .padding(.horizontal)
+    }
+
+    private func bannerTitle(_ rec: PersonalizedRecommendation) -> String {
+        switch rec.reason {
+        case .mobility:
+            return "Mobility-friendly: Floor \(rec.floor)"
+        case .preferredFloor:
+            return "Your preferred floor: Floor \(rec.floor)"
+        case .preferredFloorFull:
+            return "Best available: Floor \(rec.floor)"
+        case .generic:
+            return "Best floor: Floor \(rec.floor)"
+        }
+    }
+
+    /// Subtitle text. When the driver has a mobility limitation we always
+    /// surface the elevator-proximity note (the spot pick is always the
+    /// lowest-numbered free spot, which is the closest to the elevator), so
+    /// the message stays accurate whether we landed on the preferred floor,
+    /// the lowest available floor, or the generic recommendation.
+    private func bannerSubtitle(_ rec: PersonalizedRecommendation, available: Int, mobility: Bool) -> String {
+        var parts = ["\(available) spot\(available == 1 ? "" : "s") available"]
+        if mobility, let spot = rec.spot {
+            parts.append("Spot \(spot.number) is closest to the elevator")
+        }
+        if case .preferredFloorFull(let fallback) = rec.reason {
+            parts.append("Your preferred floor is full, recommending Floor \(fallback) instead")
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    private func bannerIcon(_ reason: PersonalizedRecommendation.Reason, mobility: Bool) -> String {
+        // When mobility is on but the chosen reason is preferred-floor, surface
+        // a wheelchair glyph so the visual still signals accessibility.
+        if mobility, case .preferredFloor = reason { return "figure.roll" }
+        switch reason {
+        case .mobility:           return "figure.roll"
+        case .preferredFloor:     return "star.fill"
+        case .preferredFloorFull: return "arrow.triangle.swap"
+        case .generic:            return "sparkles"
+        }
+    }
+
+    private func bannerTint(_ reason: PersonalizedRecommendation.Reason) -> Color {
+        switch reason {
+        case .mobility:           return .blue
+        case .preferredFloor:     return .purple
+        case .preferredFloorFull: return .orange
+        case .generic:            return .green
         }
     }
 

--- a/sd-smart-parking/sd-smart-parking/Views/Profile/EditProfileView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Profile/EditProfileView.swift
@@ -9,11 +9,16 @@ import SwiftUI
 struct EditProfileView: View {
     // 1. Inyectamos el Repositorio
     @EnvironmentObject var userRepo: UserRepository
+    @EnvironmentObject var parkingVM: ParkingViewModel
     @Environment(\.dismiss) var dismiss
-    
+
     @State private var name: String = ""
     @State private var email: String = ""
-    
+
+    // Parking preferences (mirrors UserPreferences)
+    @State private var hasMobilityLimitation: Bool = false
+    @State private var preferredFloor: Int? = nil
+
     var body: some View {
         NavigationStack {
             Form {
@@ -23,6 +28,12 @@ struct EditProfileView: View {
                         .keyboardType(.emailAddress)
                         .autocapitalization(.none)
                 }
+
+                PreferencesSection(
+                    hasMobilityLimitation: $hasMobilityLimitation,
+                    preferredFloor: $preferredFloor,
+                    availableFloors: availableFloors
+                )
             }
             .navigationTitle("Edit Profile")
             .onAppear {
@@ -30,6 +41,8 @@ struct EditProfileView: View {
                 if let user = userRepo.currentUser {
                     name = user.name
                     email = user.email
+                    hasMobilityLimitation = user.preferences?.hasMobilityLimitation ?? false
+                    preferredFloor = user.preferences?.preferredFloor
                 }
             }
             .toolbar {
@@ -40,11 +53,22 @@ struct EditProfileView: View {
                     Button("Save") {
                         // 3. Llamada al Repositorio (maneja lógica offline/online)
                         userRepo.updateProfile(newName: name, newEmail: email)
+                        userRepo.updatePreferences(
+                            UserPreferences(
+                                hasMobilityLimitation: hasMobilityLimitation,
+                                preferredFloor: preferredFloor
+                            )
+                        )
                         dismiss()
                     }
                     .bold()
                 }
             }
         }
+    }
+
+    private var availableFloors: [Int] {
+        let configured = max(1, parkingVM.config.numberOfFloors)
+        return Array(1...configured)
     }
 }

--- a/sd-smart-parking/sd-smart-parking/Views/Profile/PreferencesSection.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Profile/PreferencesSection.swift
@@ -1,0 +1,71 @@
+//
+//  PreferencesSection.swift
+//  sd-smart-parking
+//
+
+import SwiftUI
+
+/// Form section that lets a driver declare a mobility limitation and pick a
+/// preferred floor. Designed to be embedded inside a `Form` (e.g. EditProfileView).
+struct PreferencesSection: View {
+    @Binding var hasMobilityLimitation: Bool
+    @Binding var preferredFloor: Int?
+    let availableFloors: [Int]
+
+    var body: some View {
+        Section {
+            Toggle(isOn: $hasMobilityLimitation) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Label("Mobility-friendly recommendations", systemImage: "figure.roll")
+                        .font(.body)
+                    Text("Suggest the spot closest to the elevator on the lowest available floor.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+
+            Picker(selection: preferredFloorBinding) {
+                Text("No preference").tag(Int?.none)
+                ForEach(availableFloors, id: \.self) { floor in
+                    Text("Floor \(floor)").tag(Int?.some(floor))
+                }
+            } label: {
+                Label("Preferred floor", systemImage: "building.2.fill")
+            }
+
+            if hasMobilityLimitation, preferredFloor != nil {
+                Label(
+                    "Your preferred floor takes priority — we'll pick the spot closest to the elevator on that floor. If it's full, we'll fall back to the lowest available floor.",
+                    systemImage: "info.circle"
+                )
+                .font(.caption)
+                .foregroundColor(.secondary)
+            }
+        } header: {
+            Text("Parking preferences")
+        } footer: {
+            Text("Used by the Spots tab to personalize the recommended floor.")
+        }
+    }
+
+    /// Bridges the optional binding into the Picker (the Picker tag accepts
+    /// `Int?` directly thanks to the explicit tag types above).
+    private var preferredFloorBinding: Binding<Int?> {
+        Binding(
+            get: { preferredFloor },
+            set: { preferredFloor = $0 }
+        )
+    }
+}
+
+#Preview {
+    @Previewable @State var mobility = false
+    @Previewable @State var floor: Int? = nil
+    return Form {
+        PreferencesSection(
+            hasMobilityLimitation: $mobility,
+            preferredFloor: $floor,
+            availableFloors: [1, 2, 3]
+        )
+    }
+}

--- a/sd-smart-parking/sd-smart-parkingTests/PersonalizedRecommendationTests.swift
+++ b/sd-smart-parking/sd-smart-parkingTests/PersonalizedRecommendationTests.swift
@@ -1,0 +1,277 @@
+//
+//  PersonalizedRecommendationTests.swift
+//  sd-smart-parkingTests
+//
+
+import Foundation
+import Testing
+@testable import sd_smart_parking
+
+// MARK: - Helpers
+
+/// Build N spots on a single floor where the first `available` spots (by index)
+/// are free. Spot numbers follow the production scheme: floor*100 + index.
+private func makeFloor(_ floor: Int, available: Int, total: Int) -> [ParkingSpot] {
+    (1...total).map { idx in
+        ParkingSpot(
+            id: UUID(),
+            number: floor * 100 + idx,
+            floor: floor,
+            isAvailable: idx <= available
+        )
+    }
+}
+
+/// Build a custom set of spots for a floor by passing the indices that should
+/// be available. Used to verify "lowest-numbered available spot" picks.
+private func makeFloor(_ floor: Int, total: Int, freeIndices: Set<Int>) -> [ParkingSpot] {
+    (1...total).map { idx in
+        ParkingSpot(
+            id: UUID(),
+            number: floor * 100 + idx,
+            floor: floor,
+            isAvailable: freeIndices.contains(idx)
+        )
+    }
+}
+
+private func vm(spots: [ParkingSpot]) -> ParkingViewModel {
+    let vm = ParkingViewModel()
+    vm.spots = spots
+    return vm
+}
+
+// MARK: - PersonalizedRecommendation tests
+
+@Suite("personalizedRecommendation")
+struct PersonalizedRecommendationTests {
+
+    // MARK: No preferences → generic path
+
+    @Test func noPrefs_clearWinner_genericReason() {
+        let v = vm(spots:
+            makeFloor(1, available: 3, total: 20)
+            + makeFloor(2, available: 10, total: 20)
+            + makeFloor(3, available: 5, total: 20)
+        )
+        let rec = v.personalizedRecommendation(for: nil)
+        #expect(rec?.floor == 2)
+        #expect(rec?.reason == .generic)
+        // Lowest-numbered free spot on F2 has index 1 → number = 201
+        #expect(rec?.spot?.number == 201)
+    }
+
+    @Test func noPrefs_tie_returnsNil() {
+        let v = vm(spots:
+            makeFloor(1, available: 10, total: 20)
+            + makeFloor(2, available: 9, total: 20)
+        )
+        #expect(v.personalizedRecommendation(for: nil) == nil)
+    }
+
+    // MARK: Mobility-aware path
+
+    @Test func mobility_picksLowestFloorWithAvailability() {
+        let prefs = UserPreferences(hasMobilityLimitation: true, preferredFloor: nil)
+        let v = vm(spots:
+            makeFloor(1, available: 2, total: 20)
+            + makeFloor(2, available: 10, total: 20)
+        )
+        let rec = v.personalizedRecommendation(for: prefs)
+        #expect(rec?.floor == 1)
+        #expect(rec?.reason == .mobility)
+        #expect(rec?.spot?.number == 101)
+    }
+
+    @Test func mobility_skipsFullLowerFloor() {
+        let prefs = UserPreferences(hasMobilityLimitation: true, preferredFloor: nil)
+        let v = vm(spots:
+            makeFloor(1, available: 0, total: 20)
+            + makeFloor(2, available: 5, total: 20)
+            + makeFloor(3, available: 10, total: 20)
+        )
+        let rec = v.personalizedRecommendation(for: prefs)
+        #expect(rec?.floor == 2)
+        #expect(rec?.reason == .mobility)
+    }
+
+    @Test func mobility_allFull_returnsNil() {
+        let prefs = UserPreferences(hasMobilityLimitation: true, preferredFloor: nil)
+        let v = vm(spots:
+            makeFloor(1, available: 0, total: 20)
+            + makeFloor(2, available: 0, total: 20)
+        )
+        #expect(v.personalizedRecommendation(for: prefs) == nil)
+    }
+
+    @Test func mobility_pickIsLowestNumberedFreeSpot() {
+        // Floor 1 has indices {3, 5} free → lowest free number = 103
+        let prefs = UserPreferences(hasMobilityLimitation: true, preferredFloor: nil)
+        let v = vm(spots: makeFloor(1, total: 10, freeIndices: [3, 5]))
+        let rec = v.personalizedRecommendation(for: prefs)
+        #expect(rec?.floor == 1)
+        #expect(rec?.spot?.number == 103)
+    }
+
+    // MARK: Preferred-floor path
+
+    @Test func preferredFloor_withAvailability_winsOverGeneric() {
+        // Generic winner would be Floor 3 (most spots), but driver prefers Floor 2.
+        let prefs = UserPreferences(hasMobilityLimitation: false, preferredFloor: 2)
+        let v = vm(spots:
+            makeFloor(1, available: 1, total: 20)
+            + makeFloor(2, available: 4, total: 20)
+            + makeFloor(3, available: 15, total: 20)
+        )
+        let rec = v.personalizedRecommendation(for: prefs)
+        #expect(rec?.floor == 2)
+        #expect(rec?.reason == .preferredFloor)
+        #expect(rec?.spot?.number == 201)
+    }
+
+    @Test func preferredFloor_full_mobilityOff_fallsBackToGeneric() {
+        let prefs = UserPreferences(hasMobilityLimitation: false, preferredFloor: 2)
+        let v = vm(spots:
+            makeFloor(1, available: 2, total: 20)
+            + makeFloor(2, available: 0, total: 20)
+            + makeFloor(3, available: 10, total: 20)
+        )
+        let rec = v.personalizedRecommendation(for: prefs)
+        #expect(rec?.floor == 3)
+        if case .preferredFloorFull(let fallback) = rec?.reason {
+            #expect(fallback == 3)
+        } else {
+            Issue.record("Expected .preferredFloorFull reason, got \(String(describing: rec?.reason))")
+        }
+    }
+
+    @Test func preferredFloor_full_mobilityOn_fallsBackToLowestAvailableFloor() {
+        // Preferred floor full + mobility on → fall back to mobility logic
+        // (lowest floor with availability), not the generic recommendation.
+        let prefs = UserPreferences(hasMobilityLimitation: true, preferredFloor: 2)
+        let v = vm(spots:
+            makeFloor(1, available: 3, total: 20)
+            + makeFloor(2, available: 0, total: 20)
+            + makeFloor(3, available: 15, total: 20)
+        )
+        let rec = v.personalizedRecommendation(for: prefs)
+        #expect(rec?.floor == 1)
+        if case .preferredFloorFull(let fallback) = rec?.reason {
+            #expect(fallback == 1)
+        } else {
+            Issue.record("Expected .preferredFloorFull(fallback: 1), got \(String(describing: rec?.reason))")
+        }
+        // Spot pick is the lowest-numbered free spot on the fallback floor.
+        #expect(rec?.spot?.number == 101)
+    }
+
+    @Test func preferredFloor_full_mobilityOn_allOtherFloorsFull_returnsNil() {
+        let prefs = UserPreferences(hasMobilityLimitation: true, preferredFloor: 2)
+        let v = vm(spots:
+            makeFloor(1, available: 0, total: 20)
+            + makeFloor(2, available: 0, total: 20)
+            + makeFloor(3, available: 0, total: 20)
+        )
+        #expect(v.personalizedRecommendation(for: prefs) == nil)
+    }
+
+    @Test func preferredFloor_full_andTieElsewhere_returnsNil() {
+        // Preferred floor full, generic tie within threshold → no usable fallback.
+        let prefs = UserPreferences(hasMobilityLimitation: false, preferredFloor: 2)
+        let v = vm(spots:
+            makeFloor(1, available: 10, total: 20)
+            + makeFloor(2, available: 0, total: 20)
+            + makeFloor(3, available: 9, total: 20)
+        )
+        #expect(v.personalizedRecommendation(for: prefs) == nil)
+    }
+
+    @Test func preferredFloor_outOfRange_treatedAsFallback() {
+        // Floor 99 doesn't exist; algorithm should fall through to generic
+        // (no `preferredFloorFull` hint since the floor was never present).
+        let prefs = UserPreferences(hasMobilityLimitation: false, preferredFloor: 99)
+        let v = vm(spots:
+            makeFloor(1, available: 3, total: 20)
+            + makeFloor(2, available: 10, total: 20)
+        )
+        let rec = v.personalizedRecommendation(for: prefs)
+        #expect(rec?.floor == 2)
+        #expect(rec?.reason == .generic)
+    }
+
+    // MARK: Preferred floor wins over mobility (university classroom rationale)
+
+    @Test func preferredFloor_overridesMobility() {
+        // Wheelchair user has class on Floor 3 — they should park on Floor 3
+        // in the spot closest to the elevator, NOT on Floor 1 which would
+        // force them to take the elevator to reach class.
+        let prefs = UserPreferences(hasMobilityLimitation: true, preferredFloor: 3)
+        let v = vm(spots:
+            makeFloor(1, available: 5, total: 20)
+            + makeFloor(2, available: 8, total: 20)
+            + makeFloor(3, available: 10, total: 20)
+        )
+        let rec = v.personalizedRecommendation(for: prefs)
+        #expect(rec?.floor == 3)
+        #expect(rec?.reason == .preferredFloor)
+        // Closest-to-elevator spot on F3 = lowest spot number on F3 = 301.
+        #expect(rec?.spot?.number == 301)
+    }
+
+    // MARK: Generic spot pick is the lowest-numbered free spot
+
+    @Test func generic_picksLowestNumberedSpotOnWinningFloor() {
+        // Generic winner is Floor 1 with free spots at indices {5, 10, 12, 15};
+        // Floor 2 has 0 free → gap = 4 > 2, so the tie-suppression rule does
+        // NOT trigger. Lowest-numbered free spot on F1 is index 5 → number 105.
+        let v = vm(spots:
+            makeFloor(1, total: 20, freeIndices: [5, 10, 12, 15])
+            + makeFloor(2, available: 0, total: 20)
+        )
+        let rec = v.personalizedRecommendation(for: nil)
+        #expect(rec?.floor == 1)
+        #expect(rec?.spot?.number == 105)
+    }
+
+    // MARK: Backward compatibility — UserPreferences default init
+
+    @Test func defaultPreferences_haveNoEffect() {
+        // Default UserPreferences == no mobility, no preferred floor → generic.
+        let prefs = UserPreferences()
+        let v = vm(spots:
+            makeFloor(1, available: 2, total: 20)
+            + makeFloor(2, available: 10, total: 20)
+        )
+        let rec = v.personalizedRecommendation(for: prefs)
+        #expect(rec?.floor == 2)
+        #expect(rec?.reason == .generic)
+    }
+}
+
+// MARK: - UserPreferences (de)serialization
+
+@Suite("UserPreferences serialization")
+struct UserPreferencesSerializationTests {
+
+    @Test func roundTrip_firestore_fullPayload() {
+        let prefs = UserPreferences(hasMobilityLimitation: true, preferredFloor: 3)
+        let dict = prefs.toFirestore()
+        #expect(dict["hasMobilityLimitation"] as? Bool == true)
+        #expect(dict["preferredFloor"] as? Int == 3)
+        let decoded = UserPreferences(firestore: dict)
+        #expect(decoded == prefs)
+    }
+
+    @Test func roundTrip_firestore_omitsNilFloor() {
+        let prefs = UserPreferences(hasMobilityLimitation: false, preferredFloor: nil)
+        let dict = prefs.toFirestore()
+        #expect(dict["preferredFloor"] == nil)
+        let decoded = UserPreferences(firestore: dict)
+        #expect(decoded?.preferredFloor == nil)
+        #expect(decoded?.hasMobilityLimitation == false)
+    }
+
+    @Test func nilFirestoreData_returnsNil() {
+        #expect(UserPreferences(firestore: nil) == nil)
+    }
+}


### PR DESCRIPTION
Closes #32

## Summary

Extends the existing best-floor-recommendation engine with **per-driver context** — mobility limitation and preferred floor — and adapts the Spots banner with reason-aware copy plus a hero invitation for drivers who haven't set preferences yet.

## Why this change

This is a **university parking building** with classrooms above the parking floors. The current "best floor" recommendation is one-size-fits-all, which:

- Forces wheelchair users to find the closest-to-elevator spot themselves on whichever floor we picked.
- Ignores that a driver may want to park on the floor where their class is.

This PR makes the recommendation adapt to each driver's declared context.

## Architectural pattern

**Context-aware feature** built on top of MVVM:

- `Models/UserPreferences.swift` — Codable struct (mobility flag + preferred floor) + Firestore (de)serializer.
- `Models/PersonalizedRecommendation.swift` — typed result (`floor`, `spot?`, `Reason` enum: `mobility` / `preferredFloor` / `preferredFloorFull(fallback:)` / `generic`).
- `ViewModels/ParkingViewModel.personalizedRecommendation(for:)` — single entry point honoring the priority order, leaving existing `recommendedFloor` / `floorAvailability` untouched.
- `Repositories/UserRepository.updatePreferences` — mirrors the existing offline-first `updateProfile` pattern (local cache + Firestore + queued `PendingAction`).
- `Views/Profile/PreferencesSection.swift` — Form section embedded in `EditProfileView`.
- `Views/Parking/SpotsView.swift` — adds the hero card (no-prefs drivers) + reason-aware banner + "Edit preferences" pill (prefs drivers).

## Priority order

1. **Preferred floor with availability** wins (university classroom rationale: a wheelchair user with class on Floor 2 should park on Floor 2 in the elevator-closest spot, not on Floor 1 forcing an extra elevator trip up).
2. **Mobility** is the fallback when no preferred floor is set or it's full (lowest floor with availability).
3. **Generic** `recommendedFloor` is the final fallback (mobility off + preferred full).

The spot pick inside the chosen floor is **always** the lowest-numbered free spot — closest to the elevator/stairs core.

## What changed

### New files

- `sd-smart-parking/Models/UserPreferences.swift`
- `sd-smart-parking/Models/PersonalizedRecommendation.swift`
- `sd-smart-parking/Views/Profile/PreferencesSection.swift`
- `sd-smart-parkingTests/PersonalizedRecommendationTests.swift`

### Modified files

- `sd-smart-parking/Models/User.swift` — optional `preferences` field (Codable forward-compatible).
- `sd-smart-parking/FileManagers/PendingAction.swift` — `.updatePreferences` action type.
- `sd-smart-parking/Repositories/UserRepository.swift` — `updatePreferences`, `uploadPreferencesToFirebase`, queue drain.
- `sd-smart-parking/ViewModels/AuthViewModel.swift` — Firestore decode for preferences; mocks updated.
- `sd-smart-parking/ViewModels/ParkingViewModel.swift` — `personalizedRecommendation(for:)` and two private helpers.
- `sd-smart-parking/Views/Profile/EditProfileView.swift` — preferences section, save wiring.
- `sd-smart-parking/Views/Parking/SpotsView.swift` — hero card + reason-aware banner + edit pill.

## Tests

- `build_sim` — ✅ succeeded (`iPhone 17 Pro` / iOS 26.4).
- `test_sim` — ✅ **105 / 105 passing** (Swift Testing).
- 18 new tests covering: priority order (preferred-overrides-mobility), mobility lowest-floor pick, mobility skip-full-floor, mobility-on-preferred-full fallback, mobility-off-preferred-full fallback, no-fallback edge cases, generic lowest-spot pick, default-prefs no-op, Firestore round-trip.
- All 12 pre-existing `ParkingViewModelTests` still pass — original `recommendedFloor` / `floorAvailability` were not modified.

## Test plan (manual)

Sign in as a driver. On the Spots tab:

- [x] **No preferences (fresh driver):** Hero card "Personalize your spot" appears at the top with a prominent CTA. Generic recommendation banner (if any) renders below it.
- [x] **Set mobility-only:** Banner switches to **blue** tint, `figure.roll` icon, title `Mobility-friendly: Floor X`, subtitle includes `Spot Y is closest to the elevator`. X is the **lowest** floor with availability.
- [x] **Set preferred floor only:** Banner is **purple**, `star.fill` icon, title `Your preferred floor: Floor X`.
- [x] **Set both (mobility + preferred):** Banner is **purple** but the icon switches to `figure.roll`; subtitle includes the elevator note. Preferred floor wins on the floor axis; mobility wins on the spot axis.
- [x] **Preferred floor full + mobility off:** Banner is **orange**, `arrow.triangle.swap` icon, title `Best available: Floor Y`, subtitle ends with `Your preferred floor is full, recommending Floor Y instead`. Y is the generic recommendation.
- [x] **Preferred floor full + mobility on:** Same banner as above but Y is the **lowest floor with availability** (mobility fallback), and the elevator note is also present.
- [x] **Returning driver with prefs:** No hero card. Banner shows the personalized recommendation with a small "Edit preferences" pill at the bottom.
- [x] **Offline path:** Enable airplane mode, change preferences, save. Local cache updates immediately. Re-enable network → `syncPendingActions` drains the `.updatePreferences` queue to Firestore.

## Out of scope

- Surfacing "your preferred floor was removed" when `ParkingConfig` shrinks below the saved value.
- Cross-device onboarding state.
- Automated UI tests past the auth gate.