### PR TITLE
✨ feat(ios): derive peak/valley hours from Firestore + insights sheet

### DIFF
--- a/sd-smart-parking/sd-smart-parking/Models/HistoricDemandSchedule.swift
+++ b/sd-smart-parking/sd-smart-parking/Models/HistoricDemandSchedule.swift
@@ -1,0 +1,134 @@
+//
+//  HistoricDemandSchedule.swift
+//  sd-smart-parking
+//
+
+import Foundation
+
+/// Per-hour peak/valley classification derived from historic `VehicleRecord`
+/// entries in Firestore. When enough samples are available, this is used in
+/// place of `PeakHoursSchedule`'s hardcoded ranges.
+///
+/// Algorithm per bucket (weekday / weekend):
+/// 1. Build a 24-hour histogram of entry counts.
+/// 2. Compute mean and standard deviation over the *active* hours (hours with
+///    at least one entry), so dead-of-night zeros don't pull the mean down.
+/// 3. Classify each active hour: `peak` if count ≥ mean + 0.5σ,
+///    `valley` if count ≤ max(1, mean − 0.5σ), else `normal`.
+/// 4. Merge contiguous peak/valley hours into ranges compatible with the
+///    existing countdown logic.
+struct HistoricDemandSchedule: Equatable {
+    let weekdayPeakRanges: [HourRange]
+    let weekdayValleyRanges: [HourRange]
+    let weekendPeakRanges: [HourRange]
+    let weekendValleyRanges: [HourRange]
+    let sampleSize: Int
+
+    struct HourRange: Equatable {
+        let start: Int
+        let end: Int
+    }
+
+    static let minSampleSize = 20
+    private static let stddevMultiplier = 0.5
+
+    /// Returns `nil` when the total number of entry records is below
+    /// `minSampleSize`, or when no bucket yields any classified hour — callers
+    /// should fall back to `PeakHoursSchedule`'s hardcoded defaults in that case.
+    static func build(from records: [VehicleRecord]) -> HistoricDemandSchedule? {
+        let entries = records.filter { $0.type == .entry }
+        guard entries.count >= minSampleSize else { return nil }
+
+        let calendar = Calendar.current
+        var weekdayHistogram = Array(repeating: 0, count: 24)
+        var weekendHistogram = Array(repeating: 0, count: 24)
+        var weekdayCount = 0
+        var weekendCount = 0
+
+        for record in entries {
+            let components = calendar.dateComponents([.hour, .weekday], from: record.timestamp)
+            guard let hour = components.hour, (0..<24).contains(hour) else { continue }
+            let weekday = components.weekday ?? 0
+            let isWeekend = (weekday == 1 || weekday == 7)
+            if isWeekend {
+                weekendHistogram[hour] += 1
+                weekendCount += 1
+            } else {
+                weekdayHistogram[hour] += 1
+                weekdayCount += 1
+            }
+        }
+
+        let (weekdayPeaks, weekdayValleys) = weekdayCount >= minSampleSize
+            ? classify(weekdayHistogram)
+            : ([], [])
+        let (weekendPeaks, weekendValleys) = weekendCount >= minSampleSize
+            ? classify(weekendHistogram)
+            : ([], [])
+
+        let classifiedAnything =
+            !weekdayPeaks.isEmpty || !weekdayValleys.isEmpty ||
+            !weekendPeaks.isEmpty || !weekendValleys.isEmpty
+        guard classifiedAnything else { return nil }
+
+        return HistoricDemandSchedule(
+            weekdayPeakRanges: weekdayPeaks,
+            weekdayValleyRanges: weekdayValleys,
+            weekendPeakRanges: weekendPeaks,
+            weekendValleyRanges: weekendValleys,
+            sampleSize: weekdayCount + weekendCount
+        )
+    }
+
+    /// Hours that count as "active" — at least one entry observed. At least
+    /// three active hours are required to produce a meaningful distribution.
+    private static func classify(_ histogram: [Int]) -> (peaks: [HourRange], valleys: [HourRange]) {
+        let active = histogram.enumerated().filter { $0.element > 0 }
+        guard active.count >= 3 else { return ([], []) }
+
+        let values = active.map { Double($0.element) }
+        let mean = values.reduce(0, +) / Double(values.count)
+        let variance = values.map { ($0 - mean) * ($0 - mean) }.reduce(0, +) / Double(values.count)
+        let stddev = variance.squareRoot()
+
+        // Flat histogram → nothing worth classifying.
+        guard stddev > 0 else { return ([], []) }
+
+        let peakThreshold = mean + stddevMultiplier * stddev
+        let valleyThreshold = max(1.0, mean - stddevMultiplier * stddev)
+
+        var peakHours: [Int] = []
+        var valleyHours: [Int] = []
+        for (hour, count) in active {
+            let c = Double(count)
+            if c >= peakThreshold {
+                peakHours.append(hour)
+            } else if c <= valleyThreshold {
+                valleyHours.append(hour)
+            }
+        }
+
+        return (mergeRanges(peakHours), mergeRanges(valleyHours))
+    }
+
+    /// Collapses a sorted list of individual hours into half-open ranges
+    /// `[start, end)` the existing countdown logic expects.
+    private static func mergeRanges(_ hours: [Int]) -> [HourRange] {
+        guard !hours.isEmpty else { return [] }
+        let sorted = hours.sorted()
+        var result: [HourRange] = []
+        var start = sorted[0]
+        var prev = sorted[0]
+        for h in sorted.dropFirst() {
+            if h == prev + 1 {
+                prev = h
+            } else {
+                result.append(HourRange(start: start, end: prev + 1))
+                start = h
+                prev = h
+            }
+        }
+        result.append(HourRange(start: start, end: prev + 1))
+        return result
+    }
+}

--- a/sd-smart-parking/sd-smart-parking/Models/ParkingDemandInsights.swift
+++ b/sd-smart-parking/sd-smart-parking/Models/ParkingDemandInsights.swift
@@ -1,0 +1,123 @@
+//
+//  ParkingDemandInsights.swift
+//  sd-smart-parking
+//
+
+import Foundation
+
+/// Hour-by-hour view of entries and exits derived from `VehicleRecord`s. Feeds
+/// the insights sheet opened from the dashboard banner.
+///
+/// Separate from `HistoricDemandSchedule`:
+/// - `HistoricDemandSchedule` collapses hours into peak/valley ranges for the
+///   banner and gates on sample size for classification accuracy.
+/// - `ParkingDemandInsights` exposes the raw counts for charting and produces
+///   arrival/departure recommendations. It is always buildable (returns empty
+///   histograms when there is no data) so the sheet can explain the
+///   cold-start state instead of failing to open.
+struct ParkingDemandInsights: Equatable {
+
+    struct HourlyCount: Identifiable, Equatable {
+        let hour: Int
+        let count: Int
+        var id: Int { hour }
+        /// `08:00`-style label, suitable for chart axis marks.
+        var label: String { String(format: "%02d:00", hour) }
+    }
+
+    let weekdayEntryCounts: [HourlyCount]
+    let weekdayExitCounts: [HourlyCount]
+    let weekendEntryCounts: [HourlyCount]
+    let weekendExitCounts: [HourlyCount]
+    let totalEntries: Int
+    let totalExits: Int
+
+    /// Minimum number of entries/exits required inside the selected bucket
+    /// before arrival/departure recommendations are shown. Below this, every
+    /// hour is essentially tied at 0–1 and picking a "best" hour is noise.
+    static let minSampleForRecommendation = 10
+
+    static func build(from records: [VehicleRecord]) -> ParkingDemandInsights {
+        let calendar = Calendar.current
+        var weekdayEntry = Array(repeating: 0, count: 24)
+        var weekdayExit = Array(repeating: 0, count: 24)
+        var weekendEntry = Array(repeating: 0, count: 24)
+        var weekendExit = Array(repeating: 0, count: 24)
+        var totalEntries = 0
+        var totalExits = 0
+
+        for record in records {
+            let comps = calendar.dateComponents([.hour, .weekday], from: record.timestamp)
+            guard let hour = comps.hour, (0..<24).contains(hour) else { continue }
+            let isWeekend = (comps.weekday == 1 || comps.weekday == 7)
+            switch record.type {
+            case .entry:
+                totalEntries += 1
+                if isWeekend { weekendEntry[hour] += 1 } else { weekdayEntry[hour] += 1 }
+            case .exit:
+                totalExits += 1
+                if isWeekend { weekendExit[hour] += 1 } else { weekdayExit[hour] += 1 }
+            }
+        }
+
+        return ParkingDemandInsights(
+            weekdayEntryCounts: toHourly(weekdayEntry),
+            weekdayExitCounts: toHourly(weekdayExit),
+            weekendEntryCounts: toHourly(weekendEntry),
+            weekendExitCounts: toHourly(weekendExit),
+            totalEntries: totalEntries,
+            totalExits: totalExits
+        )
+    }
+
+    private static func toHourly(_ counts: [Int]) -> [HourlyCount] {
+        counts.enumerated().map { HourlyCount(hour: $0.offset, count: $0.element) }
+    }
+
+    // MARK: - Recommendations
+
+    /// Operating-hour slots with the fewest historic entries — least
+    /// competition for spots when arriving. Hours with zero recorded activity
+    /// are excluded: a 0-count hour is ambiguous (truly idle vs. never
+    /// observed), so we only recommend hours backed by real evidence. Returns
+    /// an empty array below `minSampleForRecommendation`.
+    func bestEntryHours(weekend: Bool, openingHour: Int, closingHour: Int, topN: Int = 3) -> [HourlyCount] {
+        let bucket = weekend ? weekendEntryCounts : weekdayEntryCounts
+        let bucketTotal = bucket.reduce(0) { $0 + $1.count }
+        guard bucketTotal >= Self.minSampleForRecommendation else { return [] }
+        return Array(
+            bucket
+                .filter { (openingHour..<closingHour).contains($0.hour) && $0.count > 0 }
+                .sorted { $0.count < $1.count }
+                .prefix(topN)
+        )
+    }
+
+    /// Operating-hour slots with the fewest historic exits — quietest
+    /// departure windows, so drivers avoid a rush at the exit gate. Same
+    /// evidence filter as `bestEntryHours`.
+    func bestExitHours(weekend: Bool, openingHour: Int, closingHour: Int, topN: Int = 3) -> [HourlyCount] {
+        let bucket = weekend ? weekendExitCounts : weekdayExitCounts
+        let bucketTotal = bucket.reduce(0) { $0 + $1.count }
+        guard bucketTotal >= Self.minSampleForRecommendation else { return [] }
+        return Array(
+            bucket
+                .filter { (openingHour..<closingHour).contains($0.hour) && $0.count > 0 }
+                .sorted { $0.count < $1.count }
+                .prefix(topN)
+        )
+    }
+
+    func totalForBucket(weekend: Bool) -> (entries: Int, exits: Int) {
+        if weekend {
+            return (
+                weekendEntryCounts.reduce(0) { $0 + $1.count },
+                weekendExitCounts.reduce(0) { $0 + $1.count }
+            )
+        }
+        return (
+            weekdayEntryCounts.reduce(0) { $0 + $1.count },
+            weekdayExitCounts.reduce(0) { $0 + $1.count }
+        )
+    }
+}

--- a/sd-smart-parking/sd-smart-parking/Models/ParkingTimeStatus.swift
+++ b/sd-smart-parking/sd-smart-parking/Models/ParkingTimeStatus.swift
@@ -23,14 +23,18 @@ enum ParkingOperatingStatus: Equatable {
 
 // MARK: - Peak Hours Schedule
 
-// TODO: Replace hardcoded schedule with Firestore-derived dynamic values
+/// Temporal classification of the current hour. When a
+/// `HistoricDemandSchedule` is supplied (computed from Firestore entries) it
+/// takes priority for the matching weekday/weekend bucket. The hardcoded
+/// weekday/weekend ranges remain as a cold-start fallback for when there are
+/// not enough historic records yet.
 struct PeakHoursSchedule {
 
-    // Weekday schedule (Mon–Fri)
+    // Fallback weekday schedule (Mon–Fri)
     static let weekdayPeakRanges: [(start: Int, end: Int)] = [(6, 9)]
     static let weekdayValleyRanges: [(start: Int, end: Int)] = [(12, 15)]
 
-    // Weekend schedule (Sat–Sun): no peaks, valley all operating hours
+    // Fallback weekend schedule (Sat–Sun)
     static let weekendPeakRanges: [(start: Int, end: Int)] = []
     static let weekendValleyRanges: [(start: Int, end: Int)] = [(6, 22)]
 
@@ -39,13 +43,13 @@ struct PeakHoursSchedule {
         return weekday == 1 || weekday == 7
     }
 
-    static func demandLevel(at date: Date) -> DemandLevel {
-        let calendar = Calendar.current
-        let hour = calendar.component(.hour, from: date)
+    static func demandLevel(
+        at date: Date,
+        using schedule: HistoricDemandSchedule? = nil
+    ) -> DemandLevel {
+        let hour = Calendar.current.component(.hour, from: date)
         let weekend = isWeekend(at: date)
-
-        let peaks = weekend ? weekendPeakRanges : weekdayPeakRanges
-        let valleys = weekend ? weekendValleyRanges : weekdayValleyRanges
+        let (peaks, valleys) = effectiveRanges(weekend: weekend, schedule: schedule)
 
         for range in peaks {
             if hour >= range.start && hour < range.end { return .peak }
@@ -76,7 +80,12 @@ struct PeakHoursSchedule {
         return .open
     }
 
-    static func transitionCountdown(at date: Date, openingHour: Int, closingHour: Int) -> String? {
+    static func transitionCountdown(
+        at date: Date,
+        openingHour: Int,
+        closingHour: Int,
+        using schedule: HistoricDemandSchedule? = nil
+    ) -> String? {
         let status = operatingStatus(at: date, openingHour: openingHour, closingHour: closingHour)
         guard case .open = status else { return nil }
 
@@ -88,9 +97,8 @@ struct PeakHoursSchedule {
         let closingMinutes = closingHour * 60
         let weekend = isWeekend(at: date)
 
-        let peaks = weekend ? weekendPeakRanges : weekdayPeakRanges
-        let valleys = weekend ? weekendValleyRanges : weekdayValleyRanges
-        let level = demandLevel(at: date)
+        let (peaks, valleys) = effectiveRanges(weekend: weekend, schedule: schedule)
+        let level = demandLevel(at: date, using: schedule)
 
         switch level {
         case .peak:
@@ -122,6 +130,29 @@ struct PeakHoursSchedule {
             }
         }
         return nil
+    }
+
+    /// Prefer the historic schedule's ranges for the current bucket
+    /// (weekday/weekend) when it classified anything there; otherwise use the
+    /// hardcoded fallback so drivers still get meaningful banners on days with
+    /// no history yet.
+    private static func effectiveRanges(
+        weekend: Bool,
+        schedule: HistoricDemandSchedule?
+    ) -> (peaks: [(start: Int, end: Int)], valleys: [(start: Int, end: Int)]) {
+        if let schedule {
+            let historicPeaks = weekend ? schedule.weekendPeakRanges : schedule.weekdayPeakRanges
+            let historicValleys = weekend ? schedule.weekendValleyRanges : schedule.weekdayValleyRanges
+            if !historicPeaks.isEmpty || !historicValleys.isEmpty {
+                return (
+                    historicPeaks.map { (start: $0.start, end: $0.end) },
+                    historicValleys.map { (start: $0.start, end: $0.end) }
+                )
+            }
+        }
+        let peaks = weekend ? weekendPeakRanges : weekdayPeakRanges
+        let valleys = weekend ? weekendValleyRanges : weekdayValleyRanges
+        return (peaks, valleys)
     }
 
     private static func formatCountdown(_ totalMinutes: Int, suffix: String) -> String {

--- a/sd-smart-parking/sd-smart-parking/ViewModels/ParkingViewModel.swift
+++ b/sd-smart-parking/sd-smart-parking/ViewModels/ParkingViewModel.swift
@@ -17,6 +17,10 @@ class ParkingViewModel: ObservableObject {
     @Published var isLoading: Bool = false
     @Published var errorMessage: String? = nil
     @Published var activeUserRecords: [VehicleRecord] = []
+    /// Peak/valley ranges derived from the latest `vehicleRecords` snapshot.
+    /// Nil when there aren't enough historic entries yet — callers fall back
+    /// to `PeakHoursSchedule`'s hardcoded ranges.
+    @Published var historicSchedule: HistoricDemandSchedule?
      
     let db = Firestore.firestore()
     private var spotsListener: ListenerRegistration?
@@ -209,7 +213,7 @@ class ParkingViewModel: ObservableObject {
                           let type      = RecordType(rawValue: typeRaw),
                           let timestamp = (data["timestamp"] as? Timestamp)?.dateValue()
                     else { return nil }
- 
+
                     return VehicleRecord(
                         id: doc.documentID,
                         plate: plate,
@@ -225,6 +229,7 @@ class ParkingViewModel: ObservableObject {
                         hitDailyCap: data["hitDailyCap"] as? Bool ?? false
                     )
                 }
+                self.historicSchedule = HistoricDemandSchedule.build(from: self.vehicleRecords)
             }
     }
  

--- a/sd-smart-parking/sd-smart-parking/Views/Components/ParkingStatusBannerView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Components/ParkingStatusBannerView.swift
@@ -8,6 +8,8 @@ import SwiftUI
 struct ParkingStatusBannerView: View {
     let demandLevel: DemandLevel
     var countdown: String? = nil
+    /// Renders a trailing chevron when the banner is interactive (tappable).
+    var showsDisclosure: Bool = false
 
     private var icon: String {
         switch demandLevel {
@@ -56,6 +58,14 @@ struct ParkingStatusBannerView: View {
                 }
             }
             Spacer()
+            if showsDisclosure {
+                Image(systemName: "chart.bar.fill")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(foregroundColor.opacity(0.7))
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(foregroundColor.opacity(0.5))
+            }
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 10)

--- a/sd-smart-parking/sd-smart-parking/Views/Usuario/Dashboard/DashboardView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Usuario/Dashboard/DashboardView.swift
@@ -15,6 +15,7 @@ struct DashboardView: View {
     @EnvironmentObject var authVM: AuthViewModel
     @State private var showTripPlanner = false
     @State private var showHistory = false
+    @State private var showDemandInsights = false
     
     var body: some View {
         ZStack(alignment: .top) {
@@ -47,19 +48,32 @@ struct DashboardView: View {
                             openingHour: vm.config.openingHour,
                             closingHour: vm.config.closingHour
                         )
-                        let demandLevel = PeakHoursSchedule.demandLevel(at: now)
+                        let demandLevel = PeakHoursSchedule.demandLevel(
+                            at: now,
+                            using: vm.historicSchedule
+                        )
                         let countdown = PeakHoursSchedule.transitionCountdown(
                             at: now,
                             openingHour: vm.config.openingHour,
-                            closingHour: vm.config.closingHour
+                            closingHour: vm.config.closingHour,
+                            using: vm.historicSchedule
                         )
 
                         VStack(spacing: 0) {
                             switch operatingStatus {
                             case .open:
-                                ParkingStatusBannerView(demandLevel: demandLevel, countdown: countdown)
-                                    .padding(.horizontal, 20)
-                                    .padding(.bottom, 12)
+                                Button {
+                                    showDemandInsights = true
+                                } label: {
+                                    ParkingStatusBannerView(
+                                        demandLevel: demandLevel,
+                                        countdown: countdown,
+                                        showsDisclosure: true
+                                    )
+                                }
+                                .buttonStyle(.plain)
+                                .padding(.horizontal, 20)
+                                .padding(.bottom, 12)
                             case .closingSoon(let mins):
                                 ClosingSoonBannerView(minutesLeft: mins)
                                     .padding(.horizontal, 20)
@@ -128,6 +142,13 @@ struct DashboardView: View {
         .sheet(isPresented: $showTripPlanner) {
             TripPlannerSheetView()
                 .environmentObject(vm.config)
+        }
+        .sheet(isPresented: $showDemandInsights) {
+            ParkingDemandInsightsView(
+                records: vm.vehicleRecords,
+                openingHour: vm.config.openingHour,
+                closingHour: vm.config.closingHour
+            )
         }
     }
     

--- a/sd-smart-parking/sd-smart-parking/Views/Usuario/Dashboard/ParkingDemandInsightsView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Usuario/Dashboard/ParkingDemandInsightsView.swift
@@ -1,0 +1,283 @@
+//
+//  ParkingDemandInsightsView.swift
+//  sd-smart-parking
+//
+
+import SwiftUI
+import Charts
+
+/// Sheet opened from the dashboard banner. Shows hourly entry/exit patterns
+/// pulled from Firestore and surfaces the quietest arrival and departure
+/// windows so drivers can plan around the crowd.
+struct ParkingDemandInsightsView: View {
+    let records: [VehicleRecord]
+    let openingHour: Int
+    let closingHour: Int
+    /// Day type the sheet should open on — defaults to the one matching today.
+    let initialBucket: Bucket
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var bucket: Bucket
+
+    enum Bucket: String, CaseIterable, Identifiable {
+        case weekday = "Weekdays"
+        case weekend = "Weekends"
+        var id: String { rawValue }
+        var isWeekend: Bool { self == .weekend }
+    }
+
+    init(
+        records: [VehicleRecord],
+        openingHour: Int,
+        closingHour: Int,
+        initialBucket: Bucket = Self.defaultBucket(for: Date())
+    ) {
+        self.records = records
+        self.openingHour = openingHour
+        self.closingHour = closingHour
+        self.initialBucket = initialBucket
+        self._bucket = State(initialValue: initialBucket)
+    }
+
+    private static func defaultBucket(for date: Date) -> Bucket {
+        let weekday = Calendar.current.component(.weekday, from: date)
+        return (weekday == 1 || weekday == 7) ? .weekend : .weekday
+    }
+
+    private var insights: ParkingDemandInsights {
+        ParkingDemandInsights.build(from: records)
+    }
+
+    private var entryCounts: [ParkingDemandInsights.HourlyCount] {
+        let all = bucket.isWeekend ? insights.weekendEntryCounts : insights.weekdayEntryCounts
+        return all.filter { (openingHour..<closingHour).contains($0.hour) }
+    }
+
+    private var exitCounts: [ParkingDemandInsights.HourlyCount] {
+        let all = bucket.isWeekend ? insights.weekendExitCounts : insights.weekdayExitCounts
+        return all.filter { (openingHour..<closingHour).contains($0.hour) }
+    }
+
+    private var bucketTotals: (entries: Int, exits: Int) {
+        insights.totalForBucket(weekend: bucket.isWeekend)
+    }
+
+    private var bestEntryHours: [ParkingDemandInsights.HourlyCount] {
+        insights.bestEntryHours(
+            weekend: bucket.isWeekend,
+            openingHour: openingHour,
+            closingHour: closingHour
+        )
+    }
+
+    private var bestExitHours: [ParkingDemandInsights.HourlyCount] {
+        insights.bestExitHours(
+            weekend: bucket.isWeekend,
+            openingHour: openingHour,
+            closingHour: closingHour
+        )
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    Picker("Day type", selection: $bucket) {
+                        ForEach(Bucket.allCases) { b in Text(b.rawValue).tag(b) }
+                    }
+                    .pickerStyle(.segmented)
+                    .padding(.horizontal, 16)
+                    .padding(.top, 8)
+
+                    sampleSizeCaption
+
+                    chartCard(
+                        title: "Arrivals per hour",
+                        caption: "How many cars enter each hour historically",
+                        data: entryCounts,
+                        color: .blue
+                    )
+
+                    chartCard(
+                        title: "Departures per hour",
+                        caption: "How many cars leave each hour historically",
+                        data: exitCounts,
+                        color: .purple
+                    )
+
+                    recommendationCard(
+                        title: "Best times to arrive",
+                        subtitle: "Hours with the fewest recorded arrivals — easiest to find a spot",
+                        icon: "arrow.down.circle.fill",
+                        tint: .green,
+                        hours: bestEntryHours
+                    )
+
+                    recommendationCard(
+                        title: "Best times to leave",
+                        subtitle: "Hours with the fewest recorded departures — avoid the exit rush",
+                        icon: "arrow.up.circle.fill",
+                        tint: .indigo,
+                        hours: bestExitHours
+                    )
+                }
+                .padding(.bottom, 24)
+            }
+            .background(Color(.systemGroupedBackground))
+            .navigationTitle("Parking Insights")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+
+    // MARK: - Pieces
+
+    @ViewBuilder
+    private var sampleSizeCaption: some View {
+        let totals = bucketTotals
+        let captionText = totals.entries + totals.exits == 0
+            ? "No historic records for \(bucket.rawValue.lowercased()) yet. Come back after a few days of activity."
+            : "Based on \(totals.entries) arrivals and \(totals.exits) departures recorded on \(bucket.rawValue.lowercased())."
+        Text(captionText)
+            .font(.footnote)
+            .foregroundColor(.secondary)
+            .padding(.horizontal, 16)
+    }
+
+    private func chartCard(
+        title: String,
+        caption: String,
+        data: [ParkingDemandInsights.HourlyCount],
+        color: Color
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title).font(.headline)
+            Text(caption).font(.caption).foregroundColor(.secondary)
+
+            if data.contains(where: { $0.count > 0 }) {
+                Chart(data) { point in
+                    BarMark(
+                        x: .value("Hour", point.label),
+                        y: .value("Cars", point.count)
+                    )
+                    .foregroundStyle(color.gradient)
+                    .cornerRadius(4)
+                }
+                .frame(height: 180)
+                .chartXAxis {
+                    AxisMarks(values: .automatic(desiredCount: 6)) { value in
+                        AxisValueLabel { if let s = value.as(String.self) { Text(s) } }
+                        AxisGridLine()
+                    }
+                }
+                .chartYAxis {
+                    AxisMarks(position: .leading)
+                }
+            } else {
+                emptyChartPlaceholder
+            }
+        }
+        .padding(16)
+        .background(Color(.systemBackground))
+        .cornerRadius(16)
+        .padding(.horizontal, 16)
+    }
+
+    private var emptyChartPlaceholder: some View {
+        HStack {
+            Spacer()
+            VStack(spacing: 6) {
+                Image(systemName: "chart.bar.xaxis")
+                    .font(.title2)
+                    .foregroundColor(.secondary)
+                Text("Nothing recorded in this window yet.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            Spacer()
+        }
+        .frame(height: 180)
+    }
+
+    private func recommendationCard(
+        title: String,
+        subtitle: String,
+        icon: String,
+        tint: Color,
+        hours: [ParkingDemandInsights.HourlyCount]
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 10) {
+                Image(systemName: icon)
+                    .font(.title3)
+                    .foregroundColor(tint)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title).font(.headline)
+                    Text(subtitle).font(.caption).foregroundColor(.secondary)
+                }
+            }
+
+            if hours.isEmpty {
+                Text("Not enough history yet to recommend an hour. Needs at least \(ParkingDemandInsights.minSampleForRecommendation) records in this bucket.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            } else {
+                HStack(spacing: 10) {
+                    ForEach(hours) { hour in
+                        VStack(spacing: 4) {
+                            Text(hour.label)
+                                .font(.system(size: 16, weight: .semibold))
+                                .foregroundColor(tint)
+                            Text("\(hour.count) car\(hour.count == 1 ? "" : "s")")
+                                .font(.caption2)
+                                .foregroundColor(.secondary)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 10)
+                        .background(tint.opacity(0.1))
+                        .cornerRadius(10)
+                    }
+                }
+            }
+        }
+        .padding(16)
+        .background(Color(.systemBackground))
+        .cornerRadius(16)
+        .padding(.horizontal, 16)
+    }
+}
+
+#Preview("With data") {
+    let now = Date()
+    let cal = Calendar.current
+    let records: [VehicleRecord] = (0..<60).map { i in
+        let hour = [7, 8, 8, 9, 13, 14, 16, 17, 17, 18][i % 10]
+        let type: RecordType = i.isMultiple(of: 3) ? .exit : .entry
+        var comps = cal.dateComponents([.year, .month, .day], from: now)
+        comps.hour = hour
+        let date = cal.date(from: comps) ?? now
+        return VehicleRecord(
+            id: UUID().uuidString,
+            plate: "ABC\(i)",
+            type: type,
+            timestamp: date,
+            floor: nil,
+            spotNumber: nil,
+            photoURL: nil,
+            isRegistered: false,
+            ownerEmail: nil,
+            ocrConfidence: 1.0,
+            durationHours: nil,
+            hitDailyCap: false
+        )
+    }
+    return ParkingDemandInsightsView(records: records, openingHour: 6, closingHour: 22)
+}
+
+#Preview("Empty") {
+    ParkingDemandInsightsView(records: [], openingHour: 6, closingHour: 22)
+}

--- a/sd-smart-parking/sd-smart-parkingTests/HistoricDemandScheduleTests.swift
+++ b/sd-smart-parking/sd-smart-parkingTests/HistoricDemandScheduleTests.swift
@@ -1,0 +1,251 @@
+//
+//  HistoricDemandScheduleTests.swift
+//  sd-smart-parkingTests
+//
+
+import Foundation
+import Testing
+@testable import sd_smart_parking
+
+// MARK: - Helpers
+
+/// Weekday: April 9, 2026 is a Thursday.
+private let weekdayYear = 2026
+private let weekdayMonth = 4
+private let weekdayDay = 9
+
+/// Weekend: April 4, 2026 is a Saturday.
+private let weekendYear = 2026
+private let weekendMonth = 4
+private let weekendDay = 4
+
+private func weekdayEntry(hour: Int, minute: Int = 0) -> VehicleRecord {
+    var comps = DateComponents()
+    comps.year = weekdayYear
+    comps.month = weekdayMonth
+    comps.day = weekdayDay
+    comps.hour = hour
+    comps.minute = minute
+    let date = Calendar.current.date(from: comps)!
+    return VehicleRecord(
+        id: UUID().uuidString,
+        plate: "ABC123",
+        type: .entry,
+        timestamp: date,
+        floor: nil,
+        spotNumber: nil,
+        photoURL: nil,
+        isRegistered: false,
+        ownerEmail: nil,
+        ocrConfidence: 1.0,
+        durationHours: nil,
+        hitDailyCap: false
+    )
+}
+
+private func weekendEntry(hour: Int, minute: Int = 0) -> VehicleRecord {
+    var comps = DateComponents()
+    comps.year = weekendYear
+    comps.month = weekendMonth
+    comps.day = weekendDay
+    comps.hour = hour
+    comps.minute = minute
+    let date = Calendar.current.date(from: comps)!
+    return VehicleRecord(
+        id: UUID().uuidString,
+        plate: "ABC123",
+        type: .entry,
+        timestamp: date,
+        floor: nil,
+        spotNumber: nil,
+        photoURL: nil,
+        isRegistered: false,
+        ownerEmail: nil,
+        ocrConfidence: 1.0,
+        durationHours: nil,
+        hitDailyCap: false
+    )
+}
+
+/// Build `count` entries at the same hour on a weekday.
+private func weekdayEntries(hour: Int, count: Int) -> [VehicleRecord] {
+    (0..<count).map { _ in weekdayEntry(hour: hour) }
+}
+
+private func weekendEntries(hour: Int, count: Int) -> [VehicleRecord] {
+    (0..<count).map { _ in weekendEntry(hour: hour) }
+}
+
+// MARK: - Insufficient data → nil
+
+@Suite("HistoricDemandSchedule build guard")
+struct HistoricDemandScheduleBuildGuard {
+
+    @Test func returnsNilWhenUnderMinSampleSize() {
+        // 19 entries — below the 20-sample floor.
+        let records = weekdayEntries(hour: 8, count: 19)
+        #expect(HistoricDemandSchedule.build(from: records) == nil)
+    }
+
+    @Test func returnsNilWhenHistogramIsCompletelyFlat() {
+        // 30 entries all at the same hour: only one active hour,
+        // so classify() bails on the "need ≥3 active hours" guard.
+        let records = weekdayEntries(hour: 8, count: 30)
+        #expect(HistoricDemandSchedule.build(from: records) == nil)
+    }
+
+    @Test func exitRecordsAreIgnored() {
+        // 30 exits — even though there are enough records, none are entries.
+        let exits: [VehicleRecord] = (0..<30).map { _ in
+            let r = weekdayEntry(hour: 8)
+            return VehicleRecord(
+                id: r.id,
+                plate: r.plate,
+                type: .exit,
+                timestamp: r.timestamp,
+                floor: nil,
+                spotNumber: nil,
+                photoURL: nil,
+                isRegistered: false,
+                ownerEmail: nil,
+                ocrConfidence: 1.0,
+                durationHours: nil,
+                hitDailyCap: false
+            )
+        }
+        #expect(HistoricDemandSchedule.build(from: exits) == nil)
+    }
+}
+
+// MARK: - Classification
+
+@Suite("HistoricDemandSchedule classification")
+struct HistoricDemandScheduleClassification {
+
+    /// Skewed weekday histogram:
+    ///   hour  8: 15 entries   ← clear peak
+    ///   hour 12:  1 entry     ← clear valley
+    ///   hour 14:  1 entry     ← clear valley
+    ///   hour 16:  5 entries   ← normal
+    @Test func identifiesWeekdayPeakAndValleys() {
+        var records: [VehicleRecord] = []
+        records += weekdayEntries(hour: 8, count: 15)
+        records += weekdayEntries(hour: 12, count: 1)
+        records += weekdayEntries(hour: 14, count: 1)
+        records += weekdayEntries(hour: 16, count: 5)
+
+        let schedule = HistoricDemandSchedule.build(from: records)
+        #expect(schedule != nil)
+        guard let schedule else { return }
+
+        #expect(schedule.weekdayPeakRanges.contains { $0.start <= 8 && 8 < $0.end })
+        #expect(schedule.weekdayValleyRanges.contains { $0.start <= 12 && 12 < $0.end })
+        #expect(schedule.weekdayValleyRanges.contains { $0.start <= 14 && 14 < $0.end })
+        // Hour 16 should not fall in peak or valley.
+        #expect(!schedule.weekdayPeakRanges.contains { $0.start <= 16 && 16 < $0.end })
+        #expect(!schedule.weekdayValleyRanges.contains { $0.start <= 16 && 16 < $0.end })
+    }
+
+    /// Contiguous peak hours collapse into a single range.
+    @Test func mergesContiguousPeakHoursIntoRange() {
+        var records: [VehicleRecord] = []
+        records += weekdayEntries(hour: 8, count: 10)
+        records += weekdayEntries(hour: 9, count: 10)
+        records += weekdayEntries(hour: 13, count: 1)
+        records += weekdayEntries(hour: 15, count: 1)
+        records += weekdayEntries(hour: 17, count: 5)
+
+        let schedule = HistoricDemandSchedule.build(from: records)
+        #expect(schedule != nil)
+        guard let schedule else { return }
+
+        let mergedPeak = schedule.weekdayPeakRanges.first { $0.start == 8 }
+        #expect(mergedPeak != nil)
+        #expect(mergedPeak?.end == 10) // half-open: covers hours 8 and 9.
+    }
+
+    /// Weekday and weekend buckets are classified independently. Each bucket
+    /// needs ≥20 entries for `build` to invoke the classifier.
+    @Test func separatesWeekdayAndWeekendBuckets() {
+        var records: [VehicleRecord] = []
+        records += weekdayEntries(hour: 8, count: 15)
+        records += weekdayEntries(hour: 12, count: 1)
+        records += weekdayEntries(hour: 14, count: 1)
+        records += weekdayEntries(hour: 16, count: 5)
+
+        records += weekendEntries(hour: 11, count: 15)
+        records += weekendEntries(hour: 15, count: 1)
+        records += weekendEntries(hour: 17, count: 1)
+        records += weekendEntries(hour: 19, count: 5)
+
+        let schedule = HistoricDemandSchedule.build(from: records)
+        #expect(schedule != nil)
+        guard let schedule else { return }
+
+        #expect(schedule.weekdayPeakRanges.contains { $0.start <= 8 && 8 < $0.end })
+        #expect(schedule.weekendPeakRanges.contains { $0.start <= 11 && 11 < $0.end })
+        // Weekday peak should not include hour 11, weekend peak should not include hour 8.
+        #expect(!schedule.weekdayPeakRanges.contains { $0.start <= 11 && 11 < $0.end })
+        #expect(!schedule.weekendPeakRanges.contains { $0.start <= 8 && 8 < $0.end })
+    }
+}
+
+// MARK: - Integration with PeakHoursSchedule
+
+@Suite("PeakHoursSchedule with historic schedule")
+struct PeakHoursScheduleWithHistoric {
+
+    private func weekdayDate(hour: Int, minute: Int = 0) -> Date {
+        var comps = DateComponents()
+        comps.year = weekdayYear
+        comps.month = weekdayMonth
+        comps.day = weekdayDay
+        comps.hour = hour
+        comps.minute = minute
+        return Calendar.current.date(from: comps)!
+    }
+
+    @Test func usesHistoricRangesWhenAvailable() {
+        // Historic data peaks at hour 16 — different from the hardcoded 6–9 peak.
+        var records: [VehicleRecord] = []
+        records += weekdayEntries(hour: 16, count: 15)
+        records += weekdayEntries(hour: 10, count: 1)
+        records += weekdayEntries(hour: 12, count: 1)
+        records += weekdayEntries(hour: 20, count: 4)
+
+        let schedule = HistoricDemandSchedule.build(from: records)
+        #expect(schedule != nil)
+
+        // At 16:00, historic says peak; hardcoded would say normal.
+        #expect(PeakHoursSchedule.demandLevel(at: weekdayDate(hour: 16), using: schedule) == .peak)
+        // At 7:00, historic has no data → bucket has non-empty ranges (from
+        // the 16h peak + 10h/12h valleys) so historic wins and returns normal.
+        #expect(PeakHoursSchedule.demandLevel(at: weekdayDate(hour: 7), using: schedule) == .normal)
+    }
+
+    @Test func fallsBackToHardcodedWhenScheduleIsNil() {
+        // nil schedule → hardcoded weekday peak 6–9 applies.
+        #expect(PeakHoursSchedule.demandLevel(at: weekdayDate(hour: 7), using: nil) == .peak)
+        #expect(PeakHoursSchedule.demandLevel(at: weekdayDate(hour: 13), using: nil) == .valley)
+    }
+
+    @Test func transitionCountdownUsesHistoricRanges() {
+        var records: [VehicleRecord] = []
+        records += weekdayEntries(hour: 16, count: 15)
+        records += weekdayEntries(hour: 10, count: 1)
+        records += weekdayEntries(hour: 12, count: 1)
+        records += weekdayEntries(hour: 20, count: 4)
+
+        let schedule = HistoricDemandSchedule.build(from: records)
+        let countdown = PeakHoursSchedule.transitionCountdown(
+            at: weekdayDate(hour: 16, minute: 30),
+            openingHour: 6,
+            closingHour: 22,
+            using: schedule
+        )
+        #expect(countdown != nil)
+        // We're inside the historic peak at 16 — countdown must reference
+        // exit from peak, not closing.
+        #expect(countdown?.contains("normal") == true)
+    }
+}

--- a/sd-smart-parking/sd-smart-parkingTests/ParkingDemandInsightsTests.swift
+++ b/sd-smart-parking/sd-smart-parkingTests/ParkingDemandInsightsTests.swift
@@ -1,0 +1,134 @@
+//
+//  ParkingDemandInsightsTests.swift
+//  sd-smart-parkingTests
+//
+
+import Foundation
+import Testing
+@testable import sd_smart_parking
+
+private let weekdayRef = DateComponents(year: 2026, month: 4, day: 9) // Thursday
+private let weekendRef = DateComponents(year: 2026, month: 4, day: 4) // Saturday
+
+private func makeRecord(
+    type: RecordType,
+    on base: DateComponents,
+    hour: Int
+) -> VehicleRecord {
+    var comps = base
+    comps.hour = hour
+    let date = Calendar.current.date(from: comps)!
+    return VehicleRecord(
+        id: UUID().uuidString,
+        plate: "ABC123",
+        type: type,
+        timestamp: date,
+        floor: nil,
+        spotNumber: nil,
+        photoURL: nil,
+        isRegistered: false,
+        ownerEmail: nil,
+        ocrConfidence: 1.0,
+        durationHours: nil,
+        hitDailyCap: false
+    )
+}
+
+private func weekdayRecords(type: RecordType, hour: Int, count: Int) -> [VehicleRecord] {
+    (0..<count).map { _ in makeRecord(type: type, on: weekdayRef, hour: hour) }
+}
+
+private func weekendRecords(type: RecordType, hour: Int, count: Int) -> [VehicleRecord] {
+    (0..<count).map { _ in makeRecord(type: type, on: weekendRef, hour: hour) }
+}
+
+@Suite("ParkingDemandInsights histogram")
+struct ParkingDemandInsightsHistogram {
+
+    @Test func buildsEmptyHistogramsFromEmptyInput() {
+        let insights = ParkingDemandInsights.build(from: [])
+        #expect(insights.totalEntries == 0)
+        #expect(insights.totalExits == 0)
+        #expect(insights.weekdayEntryCounts.count == 24)
+        #expect(insights.weekdayEntryCounts.allSatisfy { $0.count == 0 })
+        #expect(insights.weekendExitCounts.count == 24)
+    }
+
+    @Test func countsEntriesAndExitsIntoCorrectBuckets() {
+        var records: [VehicleRecord] = []
+        records += weekdayRecords(type: .entry, hour: 8, count: 3)
+        records += weekdayRecords(type: .exit, hour: 17, count: 2)
+        records += weekendRecords(type: .entry, hour: 11, count: 4)
+        records += weekendRecords(type: .exit, hour: 15, count: 1)
+
+        let insights = ParkingDemandInsights.build(from: records)
+        #expect(insights.totalEntries == 7)
+        #expect(insights.totalExits == 3)
+        #expect(insights.weekdayEntryCounts.first { $0.hour == 8 }?.count == 3)
+        #expect(insights.weekdayExitCounts.first { $0.hour == 17 }?.count == 2)
+        #expect(insights.weekendEntryCounts.first { $0.hour == 11 }?.count == 4)
+        #expect(insights.weekendExitCounts.first { $0.hour == 15 }?.count == 1)
+        // Cross-bucket contamination check:
+        #expect(insights.weekendEntryCounts.first { $0.hour == 8 }?.count == 0)
+        #expect(insights.weekdayEntryCounts.first { $0.hour == 11 }?.count == 0)
+    }
+}
+
+@Suite("ParkingDemandInsights recommendations")
+struct ParkingDemandInsightsRecommendations {
+
+    @Test func recommendsHoursWithFewestEntriesInOperatingWindow() {
+        var records: [VehicleRecord] = []
+        records += weekdayRecords(type: .entry, hour: 8, count: 10)   // busiest
+        records += weekdayRecords(type: .entry, hour: 9, count: 2)
+        records += weekdayRecords(type: .entry, hour: 11, count: 1)   // quietest w/ evidence
+        records += weekdayRecords(type: .entry, hour: 17, count: 3)
+        // Hours with 0 recorded entries are ambiguous (quiet vs. unobserved)
+        // and must be excluded from recommendations.
+
+        let insights = ParkingDemandInsights.build(from: records)
+        let best = insights.bestEntryHours(weekend: false, openingHour: 6, closingHour: 22, topN: 2)
+        #expect(best.count == 2)
+        #expect(best.first?.hour == 11)
+        #expect(best.allSatisfy { $0.count > 0 })
+        #expect(best.allSatisfy { (6..<22).contains($0.hour) })
+    }
+
+    @Test func recommendsHoursWithFewestExits() {
+        var records: [VehicleRecord] = []
+        records += weekdayRecords(type: .exit, hour: 17, count: 10)
+        records += weekdayRecords(type: .exit, hour: 18, count: 5)
+        records += weekdayRecords(type: .exit, hour: 13, count: 1)
+
+        let insights = ParkingDemandInsights.build(from: records)
+        let best = insights.bestExitHours(weekend: false, openingHour: 6, closingHour: 22, topN: 1)
+        #expect(best.first?.hour == 13)
+        #expect(best.first?.count == 1)
+    }
+
+    @Test func excludesHoursWithNoRecordedActivity() {
+        // 12 weekday entries all clustered in one hour: enough to clear the
+        // sample floor, but only one evidence-backed hour to recommend.
+        let records = weekdayRecords(type: .entry, hour: 14, count: 12)
+        let insights = ParkingDemandInsights.build(from: records)
+        let best = insights.bestEntryHours(weekend: false, openingHour: 6, closingHour: 22, topN: 3)
+        #expect(best.count == 1)
+        #expect(best.first?.hour == 14)
+    }
+
+    @Test func emptyWhenBelowMinSampleForRecommendation() {
+        // Only 5 entries — below the 10-sample floor.
+        let records = weekdayRecords(type: .entry, hour: 8, count: 5)
+        let insights = ParkingDemandInsights.build(from: records)
+        #expect(insights.bestEntryHours(weekend: false, openingHour: 6, closingHour: 22).isEmpty)
+    }
+
+    @Test func bucketsAreIsolated() {
+        var records: [VehicleRecord] = []
+        records += weekdayRecords(type: .entry, hour: 8, count: 15)
+        // Weekend bucket has nothing — recommendation must be empty for it.
+        let insights = ParkingDemandInsights.build(from: records)
+        #expect(insights.bestEntryHours(weekend: true, openingHour: 6, closingHour: 22).isEmpty)
+        #expect(!insights.bestEntryHours(weekend: false, openingHour: 6, closingHour: 22).isEmpty)
+    }
+}


### PR DESCRIPTION
Closes #34

## Summary

- **Historic classification.** `PeakHoursSchedule` now consumes an optional `HistoricDemandSchedule` built from `vehicleRecords`. Per-hour histograms are computed per weekday/weekend bucket and classified via mean ± 0.5σ. Contiguous peak or valley hours are merged into half-open ranges compatible with the existing countdown logic.
- **Safe cold-start.** Below 20 entries per bucket, a flat histogram, or fewer than 3 active hours, the schedule falls back to the original hardcoded ranges so the banner never goes blank.
- **Tappable banner + insights sheet.** The open-state banner now opens `ParkingDemandInsightsView` — a sheet with a weekday/weekend picker, two Swift Charts bar charts (arrivals / departures per hour), and two recommendation cards: *Best times to arrive* and *Best times to leave*.
- **Honest recommendations.** Recommendations only surface hours with at least one recorded observation (0-count hours are ambiguous between "truly quiet" and "never seen"), and are suppressed entirely below a 10-sample floor per bucket.

## Architecture

MVVM, matching existing patterns:

| Layer | Files |
|---|---|
| Model | `Models/HistoricDemandSchedule.swift` (new), `Models/ParkingDemandInsights.swift` (new), `Models/ParkingTimeStatus.swift` (extended) |
| ViewModel | `ViewModels/ParkingViewModel.swift` — new `@Published historicSchedule`, recomputed inside the existing `vehicleRecords` Firestore listener |
| View | `Views/Usuario/Dashboard/ParkingDemandInsightsView.swift` (new), `Views/Usuario/Dashboard/DashboardView.swift` (sheet presentation + tap), `Views/Components/ParkingStatusBannerView.swift` (new `showsDisclosure` flag) |

No new dependencies. `Charts` was already in use by `ReportsView`.

## Changes

### Added
- `Models/HistoricDemandSchedule.swift` — histogram → peak/valley range classifier
- `Models/ParkingDemandInsights.swift` — entry/exit histograms + `bestEntryHours` / `bestExitHours`
- `Views/Usuario/Dashboard/ParkingDemandInsightsView.swift` — tappable sheet with charts + recommendation cards
- `sd-smart-parkingTests/HistoricDemandScheduleTests.swift` — 9 tests
- `sd-smart-parkingTests/ParkingDemandInsightsTests.swift` — 7 tests

### Modified
- `Models/ParkingTimeStatus.swift` — `demandLevel` and `transitionCountdown` gain optional `using: HistoricDemandSchedule?`; unchanged defaults mean existing callers continue to work
- `ViewModels/ParkingViewModel.swift` — `@Published historicSchedule` recomputed from records
- `Views/Components/ParkingStatusBannerView.swift` — `showsDisclosure` flag adds chart icon + chevron when tappable
- `Views/Usuario/Dashboard/DashboardView.swift` — wraps open-state banner in a `Button`, presents insights sheet

## Test plan

- [x] `build_sim` green on iOS Simulator (iPhone 17 Pro, iOS 26.4)
- [x] `test_sim` green — **121/121 tests pass** (105 existing + 16 new)
- [x] Driver dashboard: open state shows banner with chevron; tap opens sheet
- [x] Insights sheet: weekday / weekend picker swaps chart contents and recommendations
- [x] Insights sheet with <10 records in bucket: caption + empty recommendation state
- [x] Insights sheet with seeded entries clustered at specific hours: charts reflect cluster, best-hour cards show quietest recorded hours
- [x] Banner classification flips based on real data (not just hardcoded 6–9 / 12–15)
- [x] Closing-soon and closed banners remain non-tappable (no sheet)