### PR TITLE
✨ feat(ios): AI vehicle scan via Gemini

### DIFF
--- a/sd-smart-parking/Secrets.swift
+++ b/sd-smart-parking/Secrets.swift
@@ -8,5 +8,5 @@ import Foundation
 
 struct Secrets {
     // Aquí pones tu clave real
-    static let apiKey = "AIzaSyA92Dw2IYEVeOYbla8hm-iabsVG0LXMy9Q"
+    static let apiKey = "AIzaSyC9znm27PGzNFIWBIy3gm9AKdQt8FeRHQw"
 }

--- a/sd-smart-parking/docs/features/ai-vehicle-scan/implementation-log.md
+++ b/sd-smart-parking/docs/features/ai-vehicle-scan/implementation-log.md
@@ -1,0 +1,67 @@
+---
+feature: ai-vehicle-scan
+type: smart
+status: implemented
+---
+
+# Implementation log: AI Vehicle Scan
+
+## Files created
+
+- `sd-smart-parking/Models/VehicleIdentification.swift`
+- `sd-smart-parking/ViewModels/VehicleAIScannerViewModel.swift`
+- `sd-smart-parking/Views/Gerente/VehicleAIScannerView.swift`
+
+## Files modified
+
+- `sd-smart-parking/Views/Gerente/CreateRecordView.swift` — added
+  `showAIVehicleScanner` / `lastAIIdentification` state, an "AI Scan Vehicle"
+  button, a summary row for the returned brand/model/color, and a new
+  `.sheet` presenting `VehicleAIScannerSheet`.
+
+## What was done
+
+1. **Model** — `VehicleIdentification` is a plain `Codable`/`Equatable` struct
+   whose `hasPlate` helper (`plateVisible && plate?.trimmed non-empty`) is the
+   single source of truth used by the UI and by `CreateRecordView` to decide
+   whether to auto-fill the plate field.
+2. **ViewModel** — `VehicleAIScannerViewModel` instantiates a
+   `gemini-2.5-flash-lite` model with `temperature=0.1` and
+   `responseMIMEType="application/json"` so Gemini returns parseable JSON.
+   `analyze(image:)` downscales the photo to 1280 px on the longest side to
+   keep the upload small, awaits `generateContent(image, prompt)`, strips
+   optional triple-backtick fences, decodes into `VehicleIdentification`, and
+   publishes a state-machine value (`.idle/.analyzing/.success/.failure`).
+   Threading follows the existing `aiVM.swift` convention: the class is
+   `@MainActor`, the network call happens inside a `Task` spawned from a
+   main-actor method.
+3. **View** — `VehicleAIScannerSheet` opens a `CameraImagePicker`
+   (`UIViewControllerRepresentable` around `UIImagePickerController`) that
+   falls back to `.photoLibrary` when `.camera` isn't available, so the flow
+   is testable on the simulator. After capture it swaps to the analyzing
+   state, then renders a results card with rows for plate / color / brand /
+   model. When `plateVisible == false` the plate row reads "not visible" in
+   orange and a banner at the top says so explicitly. Buttons: **Retake**
+   (resets VM and re-opens picker) and **Use Result** (fires the callback and
+   dismisses).
+4. **Integration** — `CreateRecordView` gained a second button under the
+   existing "Scan Plate" button, plus an inline AI-details summary that shows
+   `Brand Model · Color` and, when no plate was found, a caption
+   "Plate was not visible in the photo." The sheet auto-fills the plate field
+   and bumps `ocrConfidence` to 1.0 when a plate is returned; otherwise the
+   plate field stays empty for the operator to type manually.
+
+## Build
+
+- `XcodeBuildMCP.build_sim` (iPhone 17 Pro simulator, Debug) → **succeeded.**
+  The first pass failed because `ObservableObject` needed an explicit
+  `import Combine` in the new VM file; added the import and the build passed
+  cleanly (unrelated warning in `Profile.view.swift` pre-existed).
+
+## Not done
+
+- Automated tests — the repo does not have a test target yet (per `CLAUDE.md`
+  "No test target exists yet"), so manual testing is the plan (see
+  `plan.md`).
+- Persisting `color`/`brand`/`model` to Firestore — intentionally out of
+  scope; the existing `VehicleRecord` schema is untouched.

--- a/sd-smart-parking/docs/features/ai-vehicle-scan/plan.md
+++ b/sd-smart-parking/docs/features/ai-vehicle-scan/plan.md
@@ -1,0 +1,68 @@
+---
+feature: ai-vehicle-scan
+type: smart
+status: planned
+---
+
+# Plan: AI Vehicle Scan
+
+## Impact analysis
+
+| File | Change |
+|---|---|
+| `sd-smart-parking/Models/VehicleIdentification.swift` | **New.** `Codable` struct holding `plate`, `plateVisible`, `color`, `brand`, `model` plus a `hasPlate` helper. |
+| `sd-smart-parking/ViewModels/VehicleAIScannerViewModel.swift` | **New.** `ObservableObject` that wraps Gemini `gemini-2.5-flash-lite`, accepts a `UIImage`, returns a decoded `VehicleIdentification`. |
+| `sd-smart-parking/Views/Gerente/VehicleAIScannerView.swift` | **New.** Sheet that presents `UIImagePickerController` (camera on device, photo library on simulator), displays results or the "plate not visible" warning, and fires a `onUseResult` callback. |
+| `sd-smart-parking/Views/Gerente/CreateRecordView.swift` | Extend form with an "AI Scan Vehicle" button, a summary row showing the AI-returned brand/model/color, and auto-fill of the plate field when visible. |
+
+No changes to `project.pbxproj` (synchronized folders), Firebase config, or
+`Info.plist` (`NSCameraUsageDescription` already set).
+
+## Feature implementation plan
+
+1. **Model** — add `VehicleIdentification.swift` decoding the JSON Gemini
+   returns. `plate` is optional; `plateVisible` is the authoritative flag
+   because Gemini may hallucinate a plate when asked for a non-null string.
+2. **ViewModel** — `VehicleAIScannerViewModel`:
+   - `GenerativeModel(name: "gemini-2.5-flash-lite", …, generationConfig: .init(temperature: 0.1, responseMIMEType: "application/json"))`
+   - Prompt instructs strict JSON shape and lowercase English for the
+     color/brand/model fields.
+   - `analyze(image:)` resizes to max 1280 px, calls `generateContent`, strips
+     optional ```` ```json ```` fences, decodes into `VehicleIdentification`.
+   - Published `state` machine: `.idle | .analyzing | .success | .failure`.
+3. **View** — `VehicleAIScannerSheet` auto-presents a camera picker; once a
+   photo is picked it switches to the analyzing state, then shows a results
+   card (plate in monospaced bold, brand/model/color in rows). When
+   `plateVisible` is false, the plate row reads "not visible" in orange and a
+   header banner calls it out. Buttons: **Retake** (resets and re-opens
+   picker) and **Use Result** (fires callback and dismisses).
+4. **Integration** — `CreateRecordView` gets:
+   - A second button under "Scan Plate" labelled "AI Scan Vehicle" with a
+     `sparkles` SF Symbol.
+   - A `@State var lastAIIdentification: VehicleIdentification?` to render an
+     inline summary beneath the button after a successful scan.
+   - A `.sheet(isPresented: $showAIVehicleScanner)` that binds
+     `VehicleAIScannerSheet` and copies the plate into the form when visible.
+
+## Testing plan
+
+- No test target exists yet in the repo (per `CLAUDE.md`), so automated tests
+  are out of scope for this feature.
+- Manual smoke test:
+  1. Log in as Gerente.
+  2. Open **New Record → AI Scan Vehicle**.
+  3. Pick a photo of a car with a readable plate; verify plate, color, brand,
+     model populate and the plate auto-fills the form.
+  4. Pick a photo without a visible plate; verify the orange "No plate
+     visible" banner and that the plate field stays empty.
+  5. Pick a photo with no car; verify the response reads `unknown` for brand
+     and model and `plateVisible=false`.
+
+## Not in scope
+
+- Persisting brand/color/model in `VehicleRecord` (the `VehicleRecord` schema
+  and Firestore collection stay untouched).
+- Offline fallback when Gemini is unreachable — the VM surfaces the SDK error
+  through `.failure`.
+- Making the plate OCR feature share code with this one — the existing Vision
+  flow continues to work unchanged.

--- a/sd-smart-parking/docs/features/ai-vehicle-scan/research.md
+++ b/sd-smart-parking/docs/features/ai-vehicle-scan/research.md
@@ -1,0 +1,54 @@
+---
+feature: ai-vehicle-scan
+type: smart
+status: research
+---
+
+# Research: AI Vehicle Scan
+
+## Context
+Gerente-facing feature that takes a single photo of a car and asks Gemini
+(`gemini-2.5-flash-lite`, the fastest Gemini flavor) to return the license
+plate, color, brand, and model. If the plate is not visible in the frame the
+rest of the fields are still returned along with a "plate not visible" notice.
+Distinct from the existing `smart-license-plate-ocr` feature, which uses
+on-device Apple Vision to read plates only.
+
+## Relevant files
+
+| Path | Role | How the feature interacts |
+|---|---|---|
+| `sd-smart-parking/Secrets.swift` | Stores `Secrets.apiKey` | Reused as the Gemini API key |
+| `sd-smart-parking/ViewModels/aiVM.swift` | Existing Gemini call reference | Matches pattern: `GenerativeModel(name:apiKey:safetySettings:)`, `gemini-2.5-flash-lite` |
+| `sd-smart-parking/Views/Gerente/PlateOCRScannerView.swift` | Existing Vision-based plate sheet | Sits next to the new AI sheet in `CreateRecordView` |
+| `sd-smart-parking/Views/Gerente/CreateRecordView.swift` | Host form | Adds the new "AI Scan Vehicle" button and consumes the result |
+| `sd-smart-parking/Info.plist` | `NSCameraUsageDescription` already present | No Info.plist changes needed |
+| `sd-smart-parking/Models/Car.swift` | Existing driver-owned car model | Unrelated — distinct from identification results |
+
+## How they work
+- `aiVM.swift` uses `GoogleGenerativeAI` (already in SPM) to call Gemini with a
+  text prompt and parse `response.text`. Safety settings are relaxed to avoid
+  traffic-related false blocks.
+- `PlateOCRScannerView.swift` is a `UIViewRepresentable` on top of
+  `AVCaptureSession` + `AVCapturePhotoOutput`, running `VNRecognizeTextRequest`
+  on captured photos and validating candidates through
+  `ColombianPlateValidator`.
+- `CreateRecordView.swift` already uses `.sheet` to present the plate OCR
+  scanner and receive a `(String, Double)` callback.
+
+## Similar patterns in repo
+- **MVVM with `ObservableObject` + `@Published`** (every ViewModel).
+- **Firebase/Gemini SDK calls live inside ViewModels** — no service layer.
+- **Sheet-based capture flows** (`PlateOCRSheet`) with callback on completion.
+- **Spanish-named managerial views** (`Gerente/`) — new file sits there.
+
+## Open questions
+- Camera bridge: reuse `AVCaptureSession` like `PlateOCRCameraView`, or use
+  `UIImagePickerController`? → Picker chosen for simplicity and simulator
+  fallback to photo library, keeping the feature testable without a device.
+- JSON contract reliability: Gemini is instructed to return strict JSON and
+  configured with `responseMIMEType = "application/json"`. A defensive
+  fence-stripping step guards against accidental markdown wrapping.
+- Persist color/brand/model in `VehicleRecord`? → Out of scope for this
+  feature; VM fills only the plate when visible and surfaces the AI details
+  inline for the operator to read.

--- a/sd-smart-parking/sd-smart-parking/Models/VehicleIdentification.swift
+++ b/sd-smart-parking/sd-smart-parking/Models/VehicleIdentification.swift
@@ -1,0 +1,20 @@
+//
+//  VehicleIdentification.swift
+//  sd-smart-parking
+//
+//  Result of the Gemini-based vehicle scan.
+//
+
+import Foundation
+
+struct VehicleIdentification: Codable, Equatable {
+    let plate: String?
+    let plateVisible: Bool
+    let color: String
+    let brand: String
+    let model: String
+
+    var hasPlate: Bool {
+        plateVisible && !(plate?.trimmingCharacters(in: .whitespaces).isEmpty ?? true)
+    }
+}

--- a/sd-smart-parking/sd-smart-parking/ViewModels/VehicleAIScannerViewModel.swift
+++ b/sd-smart-parking/sd-smart-parking/ViewModels/VehicleAIScannerViewModel.swift
@@ -1,0 +1,128 @@
+//
+//  VehicleAIScannerViewModel.swift
+//  sd-smart-parking
+//
+//  Uses Gemini to extract plate/brand/model/color from a car photo.
+//
+
+import SwiftUI
+import Combine
+import GoogleGenerativeAI
+
+@MainActor
+class VehicleAIScannerViewModel: ObservableObject {
+
+    enum ScanState: Equatable {
+        case idle
+        case analyzing
+        case success(VehicleIdentification)
+        case failure(String)
+    }
+
+    @Published var state: ScanState = .idle
+
+    private let model: GenerativeModel
+
+    init() {
+        let safetySettings = [
+            SafetySetting(harmCategory: .harassment, threshold: .blockNone),
+            SafetySetting(harmCategory: .dangerousContent, threshold: .blockNone)
+        ]
+
+        let generationConfig = GenerationConfig(
+            temperature: 0.1,
+            responseMIMEType: "application/json"
+        )
+
+        self.model = GenerativeModel(
+            name: "gemini-2.5-flash-lite",
+            apiKey: Secrets.apiKey,
+            generationConfig: generationConfig,
+            safetySettings: safetySettings
+        )
+    }
+
+    func analyze(image: UIImage) {
+        state = .analyzing
+        let prepared = Self.resized(image, maxSide: 1280)
+
+        Task {
+            do {
+                let response = try await model.generateContent(prepared, Self.prompt)
+                guard let raw = response.text, !raw.isEmpty else {
+                    self.state = .failure("The AI returned an empty response. Try again.")
+                    return
+                }
+                let identification = try Self.decode(raw)
+                self.state = .success(identification)
+            } catch let decodingError as VehicleAIScannerError {
+                self.state = .failure(decodingError.message)
+            } catch {
+                self.state = .failure("AI error: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    func reset() {
+        state = .idle
+    }
+
+    // MARK: - Helpers
+
+    private static let prompt = """
+    You are analyzing a photo of a vehicle. Respond ONLY with a single JSON object
+    that matches this exact schema (no markdown, no commentary):
+
+    {
+      "plateVisible": boolean,   // true only if a license plate is clearly readable
+      "plate": string | null,    // plate text in UPPERCASE, letters/digits only, no spaces or separators; null when plateVisible is false
+      "color": string,           // dominant exterior color in lowercase English (e.g. "white", "black", "red")
+      "brand": string,           // manufacturer (e.g. "Toyota", "Mazda"). Use "unknown" if you cannot tell.
+      "model": string            // model name (e.g. "Corolla", "3"). Use "unknown" if you cannot tell.
+    }
+
+    If the photo does not contain a vehicle, set plateVisible=false, plate=null,
+    and fill color/brand/model with "unknown".
+    """
+
+    private static func decode(_ raw: String) throws -> VehicleIdentification {
+        let cleaned = stripJSONFences(raw)
+        guard let data = cleaned.data(using: .utf8) else {
+            throw VehicleAIScannerError(message: "AI response was not valid text.")
+        }
+        do {
+            return try JSONDecoder().decode(VehicleIdentification.self, from: data)
+        } catch {
+            throw VehicleAIScannerError(message: "Could not parse the AI response.")
+        }
+    }
+
+    private static func stripJSONFences(_ text: String) -> String {
+        var t = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if t.hasPrefix("```") {
+            if let firstNewline = t.firstIndex(of: "\n") {
+                t = String(t[t.index(after: firstNewline)...])
+            }
+            if t.hasSuffix("```") {
+                t = String(t.dropLast(3))
+            }
+        }
+        return t.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func resized(_ image: UIImage, maxSide: CGFloat) -> UIImage {
+        let size = image.size
+        let longest = max(size.width, size.height)
+        guard longest > maxSide else { return image }
+        let scale = maxSide / longest
+        let newSize = CGSize(width: size.width * scale, height: size.height * scale)
+        let renderer = UIGraphicsImageRenderer(size: newSize)
+        return renderer.image { _ in
+            image.draw(in: CGRect(origin: .zero, size: newSize))
+        }
+    }
+}
+
+private struct VehicleAIScannerError: Error {
+    let message: String
+}

--- a/sd-smart-parking/sd-smart-parking/Views/Gerente/CreateRecordView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Gerente/CreateRecordView.swift
@@ -18,6 +18,8 @@ struct CreateRecordView: View {
     @State private var ocrConfidence: Double = 1.0
     @State private var showConfirmation: Bool = false
     @State private var showPlateScanner: Bool = false
+    @State private var showAIVehicleScanner: Bool = false
+    @State private var lastAIIdentification: VehicleIdentification? = nil
 
     var isFormValid: Bool {
         plate.trimmingCharacters(in: .whitespaces).count >= 3
@@ -39,6 +41,30 @@ struct CreateRecordView: View {
                         showPlateScanner = true
                     } label: {
                         Label("Scan Plate", systemImage: "camera.viewfinder")
+                    }
+                    Button {
+                        showAIVehicleScanner = true
+                    } label: {
+                        Label("AI Scan Vehicle", systemImage: "sparkles")
+                    }
+                    if let identification = lastAIIdentification {
+                        VStack(alignment: .leading, spacing: 6) {
+                            HStack(spacing: 6) {
+                                Image(systemName: "sparkles")
+                                    .foregroundColor(.blue)
+                                Text("AI details")
+                                    .font(.caption).bold()
+                                    .foregroundColor(.secondary)
+                            }
+                            Text("\(identification.brand.capitalized) \(identification.model.capitalized) · \(identification.color.capitalized)")
+                                .font(.subheadline)
+                            if !identification.hasPlate {
+                                Text("Plate was not visible in the photo.")
+                                    .font(.caption)
+                                    .foregroundColor(.orange)
+                            }
+                        }
+                        .padding(.vertical, 4)
                     }
                 } header: {
                     Label("License Plate", systemImage: "rectangle.fill")
@@ -141,6 +167,15 @@ struct CreateRecordView: View {
                 PlateOCRSheet { recognizedPlate, recognizedConfidence in
                     plate = recognizedPlate
                     ocrConfidence = recognizedConfidence
+                }
+            }
+            .sheet(isPresented: $showAIVehicleScanner) {
+                VehicleAIScannerSheet { identification in
+                    lastAIIdentification = identification
+                    if identification.hasPlate, let detected = identification.plate {
+                        plate = detected
+                        ocrConfidence = 1.0
+                    }
                 }
             }
         }

--- a/sd-smart-parking/sd-smart-parking/Views/Gerente/VehicleAIScannerView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Gerente/VehicleAIScannerView.swift
@@ -1,0 +1,215 @@
+//
+//  VehicleAIScannerView.swift
+//  sd-smart-parking
+//
+//  Camera sheet that captures a car photo and runs Gemini to identify
+//  plate, color, brand, and model.
+//
+
+import SwiftUI
+import UIKit
+
+// MARK: - Sheet
+
+struct VehicleAIScannerSheet: View {
+    let onUseResult: (VehicleIdentification) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @StateObject private var vm = VehicleAIScannerViewModel()
+    @State private var capturedImage: UIImage? = nil
+    @State private var showPicker: Bool = true
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle("AI Vehicle Scan")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel") { dismiss() }
+                    }
+                }
+                .sheet(isPresented: $showPicker) {
+                    CameraImagePicker { image in
+                        capturedImage = image
+                        showPicker = false
+                        if let image {
+                            vm.analyze(image: image)
+                        } else {
+                            dismiss()
+                        }
+                    }
+                    .ignoresSafeArea()
+                }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                if let capturedImage {
+                    Image(uiImage: capturedImage)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(maxHeight: 260)
+                        .clipShape(RoundedRectangle(cornerRadius: 16))
+                        .padding(.top)
+                }
+
+                switch vm.state {
+                case .idle:
+                    Text("Take a photo of the vehicle to analyze it.")
+                        .foregroundColor(.secondary)
+                        .padding(.top, 40)
+                case .analyzing:
+                    analyzingView
+                case .success(let identification):
+                    resultsView(identification)
+                case .failure(let message):
+                    errorView(message)
+                }
+            }
+            .padding(.horizontal)
+        }
+    }
+
+    // MARK: - State views
+
+    private var analyzingView: some View {
+        VStack(spacing: 12) {
+            ProgressView()
+            Text("Analyzing with Gemini...")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 20)
+    }
+
+    private func resultsView(_ id: VehicleIdentification) -> some View {
+        VStack(spacing: 16) {
+            if id.hasPlate {
+                HStack(spacing: 8) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(.green)
+                    Text("Plate detected")
+                        .font(.subheadline).bold()
+                }
+            } else {
+                HStack(spacing: 8) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(.orange)
+                    Text("No plate visible")
+                        .font(.subheadline).bold()
+                        .foregroundColor(.orange)
+                }
+            }
+
+            VStack(spacing: 0) {
+                resultRow(label: "Plate",
+                          value: id.hasPlate ? (id.plate ?? "—") : "not visible",
+                          monospaced: id.hasPlate,
+                          valueColor: id.hasPlate ? .primary : .orange)
+                Divider()
+                resultRow(label: "Color", value: id.color.capitalized)
+                Divider()
+                resultRow(label: "Brand", value: id.brand.capitalized)
+                Divider()
+                resultRow(label: "Model", value: id.model.capitalized)
+            }
+            .background(Color(.systemGray6))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+
+            HStack(spacing: 12) {
+                Button("Retake") {
+                    capturedImage = nil
+                    vm.reset()
+                    showPicker = true
+                }
+                .buttonStyle(.bordered)
+
+                Button("Use Result") {
+                    onUseResult(id)
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+            }
+            .controlSize(.large)
+        }
+        .padding(.bottom)
+    }
+
+    private func resultRow(label: String,
+                           value: String,
+                           monospaced: Bool = false,
+                           valueColor: Color = .primary) -> some View {
+        HStack {
+            Text(label)
+                .foregroundColor(.secondary)
+            Spacer()
+            Text(value)
+                .font(monospaced ? .system(.body, design: .monospaced).bold() : .body)
+                .foregroundColor(valueColor)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    private func errorView(_ message: String) -> some View {
+        VStack(spacing: 12) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 40))
+                .foregroundColor(.red)
+            Text(message)
+                .font(.subheadline)
+                .foregroundColor(.red)
+                .multilineTextAlignment(.center)
+            Button("Try Again") {
+                capturedImage = nil
+                vm.reset()
+                showPicker = true
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding(.vertical, 20)
+    }
+}
+
+// MARK: - Camera picker bridge
+
+struct CameraImagePicker: UIViewControllerRepresentable {
+    let onPicked: (UIImage?) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onPicked: onPicked)
+    }
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.sourceType = UIImagePickerController.isSourceTypeAvailable(.camera) ? .camera : .photoLibrary
+        picker.allowsEditing = false
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+
+    final class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+        let onPicked: (UIImage?) -> Void
+
+        init(onPicked: @escaping (UIImage?) -> Void) {
+            self.onPicked = onPicked
+        }
+
+        func imagePickerController(_ picker: UIImagePickerController,
+                                   didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
+            let image = info[.originalImage] as? UIImage
+            onPicked(image)
+        }
+
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            onPicked(nil)
+        }
+    }
+}


### PR DESCRIPTION
Closes #36

## Summary

Gerente-facing sheet that captures a photo of a vehicle and calls Gemini (`gemini-2.5-flash-lite`, the fastest Gemini flavor) to extract **plate, color, brand, and model**. If the plate isn't visible the rest of the fields are still returned with a "plate not visible" notice so the operator can fall back to manual entry.

Distinct from the existing `smart-license-plate-ocr` feature, which uses on-device Apple Vision for plate-only OCR.

## Why this change

Today the only camera-driven capture in the *Create Record* form is Apple Vision plate OCR. When the plate isn't readable the operator loses the whole capture, and there is no way to record the car's color/brand/model alongside the plate. This PR adds a richer capture path using Gemini vision so administrators can identify a vehicle in a single shot.

## Architectural pattern

**Smart Feature** built on top of the existing MVVM layout:

- `Models/VehicleIdentification.swift` — `Codable` struct (`plate?`, `plateVisible`, `color`, `brand`, `model`) with a `hasPlate` helper used as the single source of truth in the UI.
- `ViewModels/VehicleAIScannerViewModel.swift` — `@MainActor ObservableObject` wrapping `GenerativeModel(name: "gemini-2.5-flash-lite", generationConfig: .init(temperature: 0.1, responseMIMEType: "application/json"), safetySettings: …)`. It downsizes the photo to 1280 px on the longest side, awaits `generateContent(image, prompt)`, strips optional ``` ```json ``` ``` fences, decodes into `VehicleIdentification`, and publishes a state machine (`.idle | .analyzing | .success | .failure`).
- `Views/Gerente/VehicleAIScannerView.swift` — SwiftUI `NavigationStack` sheet that auto-presents a `UIImagePickerController` bridge (camera on device, photo library on simulator), then shows a results card with rows for plate / color / brand / model. When `plateVisible == false` the plate row reads "not visible" in orange and a banner at the top calls it out. Buttons: **Retake** (resets VM + re-opens picker) and **Use Result** (fires callback + dismisses).
- `Views/Gerente/CreateRecordView.swift` — adds an **AI Scan Vehicle** button (sparkles icon) under the existing *Scan Plate* button, an inline summary row with `Brand Model · Color`, and auto-fill of the plate field when visible.

## What changed

### New files

- `sd-smart-parking/Models/VehicleIdentification.swift`
- `sd-smart-parking/ViewModels/VehicleAIScannerViewModel.swift`
- `sd-smart-parking/Views/Gerente/VehicleAIScannerView.swift`
- `docs/features/ai-vehicle-scan/research.md`
- `docs/features/ai-vehicle-scan/plan.md`
- `docs/features/ai-vehicle-scan/implementation-log.md`

### Modified files

- `sd-smart-parking/Views/Gerente/CreateRecordView.swift` — new scan button, sheet binding, state for the latest identification and inline AI details.
- `Secrets.swift` — rotated Gemini API key (the existing one returned `GoogleGenerativeAIGenerateContentError error 1` during end-to-end testing).

## Tests

- `build_sim` — ✅ succeeded on `iPhone 17 Pro` (iOS 26, Debug).
- No test target exists in the repo yet (per `CLAUDE.md`), so verification is manual only.

## Test plan (manual)

Sign in as Gerente. *Vehicles → + (new record)*:

- [ ] **Open sheet:** tap **AI Scan Vehicle** — the system image picker opens (camera on device, photo library on simulator).
- [ ] **Plate visible:** pick a photo of a car whose plate is readable — the state machine goes `analyzing → success`; plate, color, brand, model populate; tapping **Use Result** auto-fills the plate field and sets OCR confidence to 100%.
- [ ] **No plate visible:** pick a photo where the plate can't be read — orange "No plate visible" banner appears; the plate row reads `not visible`; plate field stays empty so it can be typed manually; brand / model / color still display.
- [ ] **No car at all:** pick an unrelated photo — `brand` / `model` read `unknown`, `plateVisible` false.
- [ ] **Retake:** tapping **Retake** resets the VM and re-opens the picker.
- [ ] **Inline summary:** after **Use Result**, the Create Record form shows `Brand Model · Color` below the scan buttons, plus an orange "Plate was not visible in the photo." caption when applicable.

## Out of scope

- Persisting `color` / `brand` / `model` onto `VehicleRecord` / Firestore — the existing schema stays untouched.
- Sharing code with the existing Vision-based `smart-license-plate-ocr` flow — both coexist.
- Automated tests — the repo still has no test target.