### PR TITLE
feat(sprint3): four offline guards on Diego-authored views (PR-B)

### DIFF
--- a/sd-smart-parking/sd-smart-parking/Views/Gerente/VehicleAIScannerView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Gerente/VehicleAIScannerView.swift
@@ -15,9 +15,11 @@ struct VehicleAIScannerSheet: View {
     let onUseResult: (VehicleIdentification) -> Void
 
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var networkMonitor: NetworkMonitor
     @StateObject private var vm = VehicleAIScannerViewModel()
     @State private var capturedImage: UIImage? = nil
     @State private var showPicker: Bool = true
+    @State private var showPlateOCRFallback: Bool = false
 
     var body: some View {
         NavigationStack {
@@ -33,13 +35,30 @@ struct VehicleAIScannerSheet: View {
                     CameraImagePicker { image in
                         capturedImage = image
                         showPicker = false
-                        if let image {
+                        guard let image else {
+                            dismiss()
+                            return
+                        }
+                        if networkMonitor.isConnected {
                             vm.analyze(image: image)
                         } else {
-                            dismiss()
+                            showPlateOCRFallback = true
                         }
                     }
                     .ignoresSafeArea()
+                }
+                .sheet(isPresented: $showPlateOCRFallback) {
+                    PlateOCRSheet { plate, _ in
+                        let identification = VehicleIdentification(
+                            plate: plate,
+                            plateVisible: true,
+                            color: "unknown",
+                            brand: "unknown",
+                            model: "unknown"
+                        )
+                        onUseResult(identification)
+                        dismiss()
+                    }
                 }
         }
     }
@@ -59,6 +78,10 @@ struct VehicleAIScannerSheet: View {
 
                 switch vm.state {
                 case .idle:
+                    if !networkMonitor.isConnected {
+                        OfflineNoticeBadge(message: "Sin conexión — usaremos OCR local")
+                            .padding(.top, 12)
+                    }
                     Text("Take a photo of the vehicle to analyze it.")
                         .foregroundColor(.secondary)
                         .padding(.top, 40)

--- a/sd-smart-parking/sd-smart-parking/Views/Login/LoginView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Login/LoginView.swift
@@ -10,6 +10,7 @@ import LocalAuthentication
 
 struct LoginView: View {
     @EnvironmentObject var authVM: AuthViewModel
+    @EnvironmentObject private var networkMonitor: NetworkMonitor
     @State private var email = ""
     @State private var password = ""
     private var biometricIcon: String {
@@ -147,9 +148,18 @@ struct LoginView: View {
                             .stroke(Color.gray.opacity(0.2), lineWidth: 1)
                     )
                     .shadow(color: Color.black.opacity(0.05), radius: 3, x: 0, y: 2)
+                    .opacity(networkMonitor.isConnected ? 1.0 : 0.45)
                 }
                 .contentShape(Rectangle())
+                .disabled(!networkMonitor.isConnected || authVM.isLoading)
                 .padding(.horizontal, 24)
+
+                if !networkMonitor.isConnected {
+                    Text("Sin conexión — usa Face ID si tienes sesión guardada")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .padding(.horizontal, 24)
+                }
 
                 // MARK: - Face ID / Touch ID Button
                 Button {
@@ -224,4 +234,5 @@ struct LoginView: View {
 #Preview {
     LoginView()
         .environmentObject(AuthViewModel())
+        .environmentObject(NetworkMonitor())
 }

--- a/sd-smart-parking/sd-smart-parking/Views/Usuario/Dashboard/DashboardView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Usuario/Dashboard/DashboardView.swift
@@ -173,7 +173,8 @@ struct DashboardView: View {
             ParkingDemandInsightsView(
                 records: vm.vehicleRecords,
                 openingHour: vm.config.openingHour,
-                closingHour: vm.config.closingHour
+                closingHour: vm.config.closingHour,
+                lastSyncedAt: vm.vehicleRecords.first?.timestamp
             )
         }
     }

--- a/sd-smart-parking/sd-smart-parking/Views/Usuario/Dashboard/ParkingDemandInsightsView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Usuario/Dashboard/ParkingDemandInsightsView.swift
@@ -15,8 +15,13 @@ struct ParkingDemandInsightsView: View {
     let closingHour: Int
     /// Day type the sheet should open on — defaults to the one matching today.
     let initialBucket: Bucket
+    /// Timestamp of the most recent record at presentation time. Used to
+    /// surface freshness info when the device is offline. Optional to keep
+    /// existing call sites backward-compatible.
+    let lastSyncedAt: Date?
 
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var networkMonitor: NetworkMonitor
     @State private var bucket: Bucket
 
     enum Bucket: String, CaseIterable, Identifiable {
@@ -30,14 +35,23 @@ struct ParkingDemandInsightsView: View {
         records: [VehicleRecord],
         openingHour: Int,
         closingHour: Int,
-        initialBucket: Bucket = Self.defaultBucket(for: Date())
+        initialBucket: Bucket = Self.defaultBucket(for: Date()),
+        lastSyncedAt: Date? = nil
     ) {
         self.records = records
         self.openingHour = openingHour
         self.closingHour = closingHour
         self.initialBucket = initialBucket
+        self.lastSyncedAt = lastSyncedAt
         self._bucket = State(initialValue: initialBucket)
     }
+
+    private static let lastSyncedFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .short
+        f.timeStyle = .short
+        return f
+    }()
 
     private static func defaultBucket(for date: Date) -> Bucket {
         let weekday = Calendar.current.component(.weekday, from: date)
@@ -142,10 +156,17 @@ struct ParkingDemandInsightsView: View {
         let captionText = totals.entries + totals.exits == 0
             ? "No historic records for \(bucket.rawValue.lowercased()) yet. Come back after a few days of activity."
             : "Based on \(totals.entries) arrivals and \(totals.exits) departures recorded on \(bucket.rawValue.lowercased())."
-        Text(captionText)
-            .font(.footnote)
-            .foregroundColor(.secondary)
-            .padding(.horizontal, 16)
+        VStack(alignment: .leading, spacing: 6) {
+            if !networkMonitor.isConnected, let synced = lastSyncedAt {
+                Text("Sin conexión — mostrando datos al \(Self.lastSyncedFormatter.string(from: synced)).")
+                    .font(.footnote.weight(.semibold))
+                    .foregroundColor(.orange)
+            }
+            Text(captionText)
+                .font(.footnote)
+                .foregroundColor(.secondary)
+        }
+        .padding(.horizontal, 16)
     }
 
     private func chartCard(
@@ -276,8 +297,10 @@ struct ParkingDemandInsightsView: View {
         )
     }
     return ParkingDemandInsightsView(records: records, openingHour: 6, closingHour: 22)
+        .environmentObject(NetworkMonitor())
 }
 
 #Preview("Empty") {
     ParkingDemandInsightsView(records: [], openingHour: 6, closingHour: 22)
+        .environmentObject(NetworkMonitor())
 }

--- a/sd-smart-parking/sd-smart-parking/Views/Usuario/Dashboard/TripPlannerSheetView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Usuario/Dashboard/TripPlannerSheetView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 struct TripPlannerSheetView: View {
     @StateObject private var tripVM = TripPlannerViewModel()
     @EnvironmentObject var config: ParkingConfig
+    @EnvironmentObject private var networkMonitor: NetworkMonitor
     @Environment(\.dismiss) private var dismiss
 
     private var validationError: String? {
@@ -52,6 +53,12 @@ struct TripPlannerSheetView: View {
                         Text("\(Int(tripVM.estimatedCost()))")
                             .font(.title2.bold())
                             .foregroundColor(.blue)
+                    }
+
+                    if !networkMonitor.isConnected {
+                        OfflineNoticeBadge(
+                            message: "Sin conexión — el costo y exportar a Calendar siguen funcionando"
+                        )
                     }
 
                     if tripVM.isPeak {
@@ -102,4 +109,5 @@ struct TripPlannerSheetView: View {
 #Preview {
     TripPlannerSheetView()
         .environmentObject(ParkingConfig())
+        .environmentObject(NetworkMonitor())
 }


### PR DESCRIPTION
Closes #49.

## Summary

Adds explicit `NetworkMonitor` guards to the four Diego-authored views that
need them, all built on the shared `OfflineNoticeBadge` component from PR-A.
Covers rubric criterion 5 (Eventual Connectivity, 4 views × 5 pts = 20 pts).

- **B.1 — `VehicleAIScannerView`**: when offline, the camera-picker callback
  routes the captured image to `PlateOCRSheet` (local Vision OCR) instead of
  invoking Gemini. Surfaces an offline badge in the idle state.
- **B.2 — `TripPlannerSheetView`**: shows an offline badge between the price
  and the peak banner when offline. "Add to Calendar" stays enabled
  (EventKit is local).
- **B.3 — `ParkingDemandInsightsView`**: new optional `lastSyncedAt: Date?`
  init parameter (defaults to nil for backward-compat). When offline, the
  sample-size caption prepends a freshness line in orange. `DashboardView`
  passes `vm.vehicleRecords.first?.timestamp` so we reuse the Firestore
  listener cache without touching `ParkingViewModel` (teammate-owned).
- **B.4 — `LoginView`**: Microsoft button gets `.disabled(!isConnected || isLoading)`
  + 0.45 opacity fade, plus a caption pointing the user at the existing
  Face ID fallback. Email / Google / Biometrics buttons unchanged.

## Test plan

- [x] `xcodebuild` build_sim green on iPhone 17 (iOS 26.4).
- [x] All four affected previews updated to inject `NetworkMonitor`.
- [x] `git blame` confirms the modified blocks are Diego's.
- [x] No teammate-owned banners (`SpotsView`, `DashboardView` orange banner,
      `GerenteSummaryView`) modified. `DashboardView` only changes the call
      site arg list for `ParkingDemandInsightsView`.

## Notes for reviewers

Manual UI verification recommended:

1. With the simulator offline (Settings → Developer → Network Link Conditioner
   100% loss, or `xcrun simctl status_bar override`), open AI Vehicle Scan →
   take a photo → verify it routes to `PlateOCRSheet`.
2. Open Trip Planner offline → verify the badge appears below the price and
   "Add to Calendar" still works.
3. Open Parking Insights offline → verify the orange "Mostrando datos al ..."
   caption appears.
4. On the Login screen offline → verify the Microsoft button is grayed out
   with the helper caption underneath.