### PR TITLE
feat(sprint3): low-risk local storage strategies (PR-D)

### DIFF
--- a/sd-smart-parking/sd-smart-parking/Core/ScanStats.swift
+++ b/sd-smart-parking/sd-smart-parking/Core/ScanStats.swift
@@ -1,0 +1,48 @@
+//
+//  ScanStats.swift
+//  sd-smart-parking
+//
+//  Counts how many times each vehicle brand has been scanned, persisted via
+//  KeyValueStore. Surfaced in the Gerente profile as "Top brands scanned".
+//
+
+import Foundation
+import SwiftUI
+import Combine
+
+@MainActor
+final class ScanStats: ObservableObject {
+    static let shared = ScanStats()
+
+    private let store: KeyValueStore<String, Int>
+
+    init(store: KeyValueStore<String, Int>? = nil) {
+        self.store = store ?? KeyValueStore<String, Int>(scope: "scan_brand_count")
+    }
+
+    /// Increments the count for the given brand (case-insensitive). Skips
+    /// "unknown" results so they do not pollute the leaderboard.
+    func increment(brand: String) {
+        let normalized = brand.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty, normalized != "unknown" else { return }
+        let next = (store[normalized] ?? 0) + 1
+        store[normalized] = next
+        objectWillChange.send()
+    }
+
+    /// Returns the top `limit` brands by scan count, descending.
+    func topBrands(_ limit: Int = 3) -> [(brand: String, count: Int)] {
+        store.snapshot()
+            .sorted { lhs, rhs in
+                if lhs.value != rhs.value { return lhs.value > rhs.value }
+                return lhs.key < rhs.key
+            }
+            .prefix(limit)
+            .map { (brand: $0.key, count: $0.value) }
+    }
+
+    func reset() {
+        store.clear()
+        objectWillChange.send()
+    }
+}

--- a/sd-smart-parking/sd-smart-parking/FileManagers/KeyValueStore.swift
+++ b/sd-smart-parking/sd-smart-parking/FileManagers/KeyValueStore.swift
@@ -1,0 +1,87 @@
+//
+//  KeyValueStore.swift
+//  sd-smart-parking
+//
+//  Generic K/V store backed by a Swift Dictionary (O(1) hash lookup) with
+//  scope-namespaced JSON persistence. Same row in the rubric as Mateo's
+//  ArrayMap (also a k/v store) but a deliberately different implementation:
+//
+//    - ArrayMap: parallel sorted [keys] + [values] arrays, binary-search
+//                lookups (O(log n)).
+//    - KeyValueStore: Swift Dictionary, hash-based (O(1)).
+//
+//  Files live under Documents/diego.kv/<scope>.json so the namespace cannot
+//  collide with anything Mateo or Juanes wrote.
+//
+//  NOTE: JSONEncoder requires `Key` to be String or Int when encoding a
+//  Dictionary; that is the case for every consumer in this project (e.g.
+//  ScanStats keys brands by lowercased String).
+//
+
+import Foundation
+
+final class KeyValueStore<Key: Hashable & Codable, Value: Codable>: @unchecked Sendable {
+
+    private var storage: [Key: Value]
+    private let fileURL: URL
+    private let queue = DispatchQueue(label: "com.diego.kvstore", attributes: .concurrent)
+
+    init(scope: String, fileURL: URL? = nil) {
+        let url = fileURL ?? Self.defaultURL(scope: scope)
+        self.fileURL = url
+        self.storage = Self.loadInitial(from: url)
+    }
+
+    private static func defaultURL(scope: String) -> URL {
+        let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        let dir = docs.appendingPathComponent("diego.kv", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("\(scope).json")
+    }
+
+    private static func loadInitial(from url: URL) -> [Key: Value] {
+        guard let data = try? Data(contentsOf: url),
+              let dict = try? JSONDecoder().decode([Key: Value].self, from: data)
+        else { return [:] }
+        return dict
+    }
+
+    // MARK: - Public API
+
+    subscript(key: Key) -> Value? {
+        get { queue.sync { storage[key] } }
+        set {
+            queue.async(flags: .barrier) {
+                if let v = newValue {
+                    self.storage[key] = v
+                } else {
+                    self.storage.removeValue(forKey: key)
+                }
+                self.persist()
+            }
+        }
+    }
+
+    func put(_ value: Value, forKey key: Key) { self[key] = value }
+
+    func remove(_ key: Key) { self[key] = nil }
+
+    func snapshot() -> [Key: Value] { queue.sync { storage } }
+
+    var count: Int { queue.sync { storage.count } }
+
+    /// Drains every entry and rewrites the file to disk. Useful in tests.
+    func clear() {
+        queue.async(flags: .barrier) {
+            self.storage.removeAll()
+            self.persist()
+        }
+    }
+
+    // MARK: - Internals
+
+    private func persist() {
+        guard let data = try? JSONEncoder().encode(storage) else { return }
+        try? data.write(to: fileURL, options: .atomic)
+    }
+}

--- a/sd-smart-parking/sd-smart-parking/FileManagers/ScanHistoryStore.swift
+++ b/sd-smart-parking/sd-smart-parking/FileManagers/ScanHistoryStore.swift
@@ -1,0 +1,69 @@
+//
+//  ScanHistoryStore.swift
+//  sd-smart-parking
+//
+//  Ring-buffer JSON store of the most recent AI vehicle scans. Uses
+//  FileManager + JSONEncoder/JSONDecoder directly, not Mateo's generic
+//  DiskPersistanceManager — separate codepath, separate file
+//  (`Documents/diego.scan_history.json`), separate concurrency model.
+//
+
+import Foundation
+
+final class ScanHistoryStore: @unchecked Sendable {
+    static let shared = ScanHistoryStore()
+
+    private let fileURL: URL
+    private let maxEntries: Int
+    /// Concurrent reader queue with barrier writes — multiple loadAll() calls
+    /// stay parallel; mutations serialize.
+    private let queue = DispatchQueue(label: "com.diego.scanhistory", attributes: .concurrent)
+
+    init(fileURL: URL? = nil, maxEntries: Int = 50) {
+        self.fileURL = fileURL ?? Self.defaultURL()
+        self.maxEntries = maxEntries
+    }
+
+    private static func defaultURL() -> URL {
+        let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        return docs.appendingPathComponent("diego.scan_history.json")
+    }
+
+    /// Returns the persisted entries, newest first. Empty on miss or corruption.
+    func loadAll() -> [ScanHistoryEntry] {
+        queue.sync {
+            decode()
+        }
+    }
+
+    /// Inserts the entry at the front and trims the tail if over capacity.
+    /// Atomic write so a crash mid-save can't half-overwrite the file.
+    func append(_ entry: ScanHistoryEntry) {
+        queue.async(flags: .barrier) {
+            var current = self.decode()
+            current.insert(entry, at: 0)
+            if current.count > self.maxEntries {
+                current = Array(current.prefix(self.maxEntries))
+            }
+            self.persist(current)
+        }
+    }
+
+    func clear() {
+        queue.async(flags: .barrier) {
+            try? FileManager.default.removeItem(at: self.fileURL)
+        }
+    }
+
+    // MARK: - Internals
+
+    private func decode() -> [ScanHistoryEntry] {
+        guard let data = try? Data(contentsOf: fileURL) else { return [] }
+        return (try? JSONDecoder().decode([ScanHistoryEntry].self, from: data)) ?? []
+    }
+
+    private func persist(_ entries: [ScanHistoryEntry]) {
+        guard let data = try? JSONEncoder().encode(entries) else { return }
+        try? data.write(to: fileURL, options: .atomic)
+    }
+}

--- a/sd-smart-parking/sd-smart-parking/Models/ScanHistoryEntry.swift
+++ b/sd-smart-parking/sd-smart-parking/Models/ScanHistoryEntry.swift
@@ -1,0 +1,29 @@
+//
+//  ScanHistoryEntry.swift
+//  sd-smart-parking
+//
+//  Local-only history entry for AI vehicle scans. Codable so it round-trips
+//  through ScanHistoryStore (a separate FileManager-backed JSON store, not
+//  Mateo's DiskPersistanceManager).
+//
+
+import Foundation
+
+struct ScanHistoryEntry: Codable, Identifiable, Equatable {
+    let id: UUID
+    let identification: VehicleIdentification
+    let scannedAt: Date
+    let imageHashHex: String
+
+    init(
+        id: UUID = UUID(),
+        identification: VehicleIdentification,
+        scannedAt: Date = Date(),
+        imageHashHex: String
+    ) {
+        self.id = id
+        self.identification = identification
+        self.scannedAt = scannedAt
+        self.imageHashHex = imageHashHex
+    }
+}

--- a/sd-smart-parking/sd-smart-parking/ViewModels/VehicleAIScannerViewModel.swift
+++ b/sd-smart-parking/sd-smart-parking/ViewModels/VehicleAIScannerViewModel.swift
@@ -45,10 +45,10 @@ class VehicleAIScannerViewModel: ObservableObject {
     func analyze(image: UIImage) {
         state = .analyzing
         let prepared = Self.resized(image, maxSide: 1280)
+        let preparedJPEG = prepared.jpegData(compressionQuality: 0.7)
 
         // Cache lookup — saves a Gemini round-trip when the operator re-scans
         // the exact same vehicle photo (same JPEG bytes -> same SHA256 key).
-        let preparedJPEG = prepared.jpegData(compressionQuality: 0.7)
         let cacheKey = preparedJPEG.map { AIScanCache.key(forJPEGData: $0) }
         if let key = cacheKey, let cached = AIScanCache.shared.get(key) {
             state = .success(cached)
@@ -69,6 +69,14 @@ class VehicleAIScannerViewModel: ObservableObject {
                 if let key = cacheKey, let data = preparedJPEG {
                     AIScanCache.shared.put(identification, for: key, cost: data.count)
                 }
+
+                // Append to local scan history (Codable + FileManager). Best-effort
+                // write — failures don't surface to the user. Reuses the same
+                // SHA256 hex string the cache key already derived from the bytes.
+                let hashHex = (cacheKey as String?) ?? ""
+                ScanHistoryStore.shared.append(
+                    ScanHistoryEntry(identification: identification, imageHashHex: hashHex)
+                )
             } catch let decodingError as VehicleAIScannerError {
                 self.state = .failure(decodingError.message)
             } catch {

--- a/sd-smart-parking/sd-smart-parking/ViewModels/VehicleAIScannerViewModel.swift
+++ b/sd-smart-parking/sd-smart-parking/ViewModels/VehicleAIScannerViewModel.swift
@@ -77,6 +77,9 @@ class VehicleAIScannerViewModel: ObservableObject {
                 ScanHistoryStore.shared.append(
                     ScanHistoryEntry(identification: identification, imageHashHex: hashHex)
                 )
+
+                // Update brand stats (KeyValueStore). Ignored for "unknown".
+                ScanStats.shared.increment(brand: identification.brand)
             } catch let decodingError as VehicleAIScannerError {
                 self.state = .failure(decodingError.message)
             } catch {

--- a/sd-smart-parking/sd-smart-parking/Views/Gerente/ScanHistorySheet.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Gerente/ScanHistorySheet.swift
@@ -1,0 +1,63 @@
+//
+//  ScanHistorySheet.swift
+//  sd-smart-parking
+//
+//  Lists the most recent AI vehicle scans persisted by ScanHistoryStore.
+//
+
+import SwiftUI
+
+struct ScanHistorySheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var entries: [ScanHistoryEntry] = []
+
+    private static let dateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .short
+        f.timeStyle = .short
+        return f
+    }()
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if entries.isEmpty {
+                    VStack(spacing: 12) {
+                        Image(systemName: "tray")
+                            .font(.system(size: 36))
+                            .foregroundColor(.secondary)
+                        Text("Aún no hay scans guardados.")
+                            .foregroundColor(.secondary)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    List(entries) { entry in
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack {
+                                Text(entry.identification.plate ?? "—")
+                                    .font(.system(.body, design: .monospaced).bold())
+                                Spacer()
+                                Text(Self.dateFormatter.string(from: entry.scannedAt))
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                            Text("\(entry.identification.brand.capitalized) · \(entry.identification.model.capitalized) · \(entry.identification.color.capitalized)")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Scan History")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cerrar") { dismiss() }
+                }
+            }
+            .onAppear {
+                entries = ScanHistoryStore.shared.loadAll()
+            }
+        }
+    }
+}

--- a/sd-smart-parking/sd-smart-parking/Views/Gerente/VehicleAIScannerView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Gerente/VehicleAIScannerView.swift
@@ -20,6 +20,7 @@ struct VehicleAIScannerSheet: View {
     @State private var capturedImage: UIImage? = nil
     @State private var showPicker: Bool = true
     @State private var showPlateOCRFallback: Bool = false
+    @State private var showHistory: Bool = false
 
     var body: some View {
         NavigationStack {
@@ -30,6 +31,16 @@ struct VehicleAIScannerSheet: View {
                     ToolbarItem(placement: .cancellationAction) {
                         Button("Cancel") { dismiss() }
                     }
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button {
+                            showHistory = true
+                        } label: {
+                            Image(systemName: "clock.arrow.circlepath")
+                        }
+                    }
+                }
+                .sheet(isPresented: $showHistory) {
+                    ScanHistorySheet()
                 }
                 .sheet(isPresented: $showPicker) {
                     CameraImagePicker { image in

--- a/sd-smart-parking/sd-smart-parking/Views/Profile/EditProfileView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Profile/EditProfileView.swift
@@ -19,6 +19,10 @@ struct EditProfileView: View {
     @State private var hasMobilityLimitation: Bool = false
     @State private var preferredFloor: Int? = nil
 
+    /// Local-only display toggle persisted via UserDefaults. `diego.` prefix
+    /// keeps the namespace separate from teammate keys (e.g. biometricsEnabled).
+    @AppStorage("diego.profile.showDemandBadgeOnDashboard") private var showDemandBadge: Bool = true
+
     var body: some View {
         NavigationStack {
             Form {
@@ -34,6 +38,10 @@ struct EditProfileView: View {
                     preferredFloor: $preferredFloor,
                     availableFloors: availableFloors
                 )
+
+                Section("Display preferences") {
+                    Toggle("Mostrar badge de demanda en Dashboard", isOn: $showDemandBadge)
+                }
             }
             .navigationTitle("Edit Profile")
             .onAppear {

--- a/sd-smart-parking/sd-smart-parking/Views/Profile/Profile.view.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Profile/Profile.view.swift
@@ -88,6 +88,29 @@ struct ProfileView: View {
                     }
                 }
 
+                // Diego — Top scanned brands (Gerente only). Reads from
+                // KeyValueStore-backed ScanStats; non-destructive section
+                // appended without touching surrounding teammate code.
+                if authVM.isGerente {
+                    let top = ScanStats.shared.topBrands(3)
+                    if !top.isEmpty {
+                        Section("Top scanned brands") {
+                            ForEach(top, id: \.brand) { entry in
+                                HStack {
+                                    Text(entry.brand.capitalized)
+                                    Spacer()
+                                    Text("\(entry.count)")
+                                        .font(.caption.bold())
+                                        .padding(.horizontal, 8)
+                                        .padding(.vertical, 2)
+                                        .background(Color(.systemGray5))
+                                        .clipShape(Capsule())
+                                }
+                            }
+                        }
+                    }
+                }
+
                 // 3. Logout
                 Button(role: .destructive) {
                     authVM.signOut(userRepo: userRepo  )

--- a/sd-smart-parking/sd-smart-parking/Views/Usuario/Dashboard/TripPlannerSheetView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Usuario/Dashboard/TripPlannerSheetView.swift
@@ -11,8 +11,24 @@ struct TripPlannerSheetView: View {
     @EnvironmentObject private var networkMonitor: NetworkMonitor
     @Environment(\.dismiss) private var dismiss
 
+    /// Preference persisted across launches via UserDefaults. Prefix `diego.`
+    /// so it never collides with teammate-owned keys (e.g. `biometricsEnabled`).
+    @AppStorage("diego.tripPlanner.preferredCurrency") private var preferredCurrency: String = "COP"
+
+    /// Conservative static rate so the planner stays fully offline-friendly.
+    /// We could refresh from a rate API later; not required for the rubric.
+    private static let usdRate: Double = 4000.0
+
     private var validationError: String? {
         tripVM.validationError(openingHour: config.openingHour, closingHour: config.closingHour)
+    }
+
+    private var displayedCost: (label: String, value: String) {
+        let cop = tripVM.estimatedCost()
+        if preferredCurrency == "USD" {
+            return ("USD", String(format: "%.2f", cop / Self.usdRate))
+        }
+        return ("COP", "\(Int(cop))")
     }
 
     var body: some View {
@@ -47,10 +63,16 @@ struct TripPlannerSheetView: View {
                 }
 
                 Section("Estimated Cost") {
+                    Picker("Currency", selection: $preferredCurrency) {
+                        Text("COP").tag("COP")
+                        Text("USD").tag("USD")
+                    }
+                    .pickerStyle(.segmented)
+
                     HStack {
-                        Text("COP")
+                        Text(displayedCost.label)
                             .foregroundColor(.secondary)
-                        Text("\(Int(tripVM.estimatedCost()))")
+                        Text(displayedCost.value)
                             .font(.title2.bold())
                             .foregroundColor(.blue)
                     }

--- a/sd-smart-parking/sd-smart-parkingTests/KeyValueStoreTests.swift
+++ b/sd-smart-parking/sd-smart-parkingTests/KeyValueStoreTests.swift
@@ -1,0 +1,134 @@
+//
+//  KeyValueStoreTests.swift
+//  sd-smart-parkingTests
+//
+
+import Foundation
+import Testing
+@testable import sd_smart_parking
+
+@Suite("KeyValueStore")
+struct KeyValueStoreTests {
+
+    private func tempURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("kv-test-\(UUID().uuidString).json")
+    }
+
+    private func waitForBarrier<K, V>(on store: KeyValueStore<K, V>) {
+        // snapshot() goes through the same concurrent queue as writes, so
+        // calling it after a put/remove forces every preceding barrier to flush.
+        _ = store.snapshot()
+    }
+
+    @Test func putGetRoundTrip() async throws {
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let store = KeyValueStore<String, Int>(scope: "test", fileURL: url)
+
+        store.put(7, forKey: "alpha")
+        waitForBarrier(on: store)
+        #expect(store["alpha"] == 7)
+    }
+
+    @Test func removeNullsTheValue() async throws {
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let store = KeyValueStore<String, Int>(scope: "test", fileURL: url)
+
+        store.put(1, forKey: "a")
+        store.put(2, forKey: "b")
+        store.remove("a")
+        waitForBarrier(on: store)
+
+        #expect(store["a"] == nil)
+        #expect(store["b"] == 2)
+    }
+
+    @Test func reloadFromDiskKeepsValues() async throws {
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        do {
+            let s1 = KeyValueStore<String, Int>(scope: "test", fileURL: url)
+            s1.put(99, forKey: "persisted")
+            waitForBarrier(on: s1)
+        }
+        let s2 = KeyValueStore<String, Int>(scope: "test", fileURL: url)
+        #expect(s2["persisted"] == 99)
+    }
+
+    @Test func snapshotReflectsCurrentState() async throws {
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let store = KeyValueStore<String, Int>(scope: "test", fileURL: url)
+
+        store.put(10, forKey: "x")
+        store.put(20, forKey: "y")
+        waitForBarrier(on: store)
+
+        let snap = store.snapshot()
+        #expect(snap.count == 2)
+        #expect(snap["x"] == 10)
+        #expect(snap["y"] == 20)
+    }
+
+    @Test func clearRemovesAll() async throws {
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let store = KeyValueStore<String, Int>(scope: "test", fileURL: url)
+        store.put(1, forKey: "a")
+        waitForBarrier(on: store)
+
+        store.clear()
+        waitForBarrier(on: store)
+        #expect(store.count == 0)
+    }
+}
+
+@Suite("ScanStats")
+struct ScanStatsTests {
+
+    @MainActor
+    private func makeStats() -> ScanStats {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("scanstats-\(UUID().uuidString).json")
+        return ScanStats(
+            store: KeyValueStore<String, Int>(scope: "scanstats", fileURL: url)
+        )
+    }
+
+    @Test @MainActor func incrementCountsBrand() async throws {
+        let stats = makeStats()
+        stats.increment(brand: "Toyota")
+        stats.increment(brand: "toyota")
+        stats.increment(brand: "Mazda")
+
+        let top = stats.topBrands(5)
+        #expect(top.first?.brand == "toyota")
+        #expect(top.first?.count == 2)
+        #expect(top.contains { $0.brand == "mazda" && $0.count == 1 })
+    }
+
+    @Test @MainActor func ignoresUnknownBrand() async throws {
+        let stats = makeStats()
+        stats.increment(brand: "unknown")
+        stats.increment(brand: "  ")
+        stats.increment(brand: "Mazda")
+
+        let top = stats.topBrands(5)
+        #expect(top.count == 1)
+        #expect(top.first?.brand == "mazda")
+    }
+
+    @Test @MainActor func topBrandsRespectsLimitAndOrder() async throws {
+        let stats = makeStats()
+        for _ in 0..<3 { stats.increment(brand: "Toyota") }
+        for _ in 0..<5 { stats.increment(brand: "Mazda") }
+        for _ in 0..<1 { stats.increment(brand: "Ford") }
+
+        let top = stats.topBrands(2)
+        #expect(top.count == 2)
+        #expect(top[0].brand == "mazda")
+        #expect(top[1].brand == "toyota")
+    }
+}

--- a/sd-smart-parking/sd-smart-parkingTests/ScanHistoryStoreTests.swift
+++ b/sd-smart-parking/sd-smart-parkingTests/ScanHistoryStoreTests.swift
@@ -1,0 +1,90 @@
+//
+//  ScanHistoryStoreTests.swift
+//  sd-smart-parkingTests
+//
+
+import Foundation
+import Testing
+@testable import sd_smart_parking
+
+@Suite("ScanHistoryStore")
+struct ScanHistoryStoreTests {
+
+    private func tempURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("scan-history-test-\(UUID().uuidString).json")
+    }
+
+    private func makeEntry(plate: String = "ABC123") -> ScanHistoryEntry {
+        ScanHistoryEntry(
+            identification: VehicleIdentification(
+                plate: plate,
+                plateVisible: true,
+                color: "white",
+                brand: "toyota",
+                model: "corolla"
+            ),
+            imageHashHex: "deadbeef"
+        )
+    }
+
+    private func waitForBarrier(on store: ScanHistoryStore) {
+        // loadAll() goes through the same concurrent queue so calling it
+        // forces every preceding barrier write to complete first.
+        _ = store.loadAll()
+    }
+
+    @Test func appendThenLoadRoundTrip() async throws {
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let store = ScanHistoryStore(fileURL: url)
+
+        store.append(makeEntry(plate: "XYZ001"))
+        waitForBarrier(on: store)
+
+        let all = store.loadAll()
+        #expect(all.count == 1)
+        #expect(all.first?.identification.plate == "XYZ001")
+    }
+
+    @Test func ringBufferEvictsOldestBeyondMaxEntries() async throws {
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let store = ScanHistoryStore(fileURL: url, maxEntries: 3)
+
+        store.append(makeEntry(plate: "AAA001"))
+        store.append(makeEntry(plate: "BBB002"))
+        store.append(makeEntry(plate: "CCC003"))
+        store.append(makeEntry(plate: "DDD004")) // pushes AAA001 out
+        waitForBarrier(on: store)
+
+        let all = store.loadAll()
+        #expect(all.count == 3)
+        let plates = all.map { $0.identification.plate }
+        #expect(plates.first == "DDD004") // newest at index 0
+        #expect(!plates.contains("AAA001"))
+    }
+
+    @Test func corruptionReturnsEmpty() async throws {
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        try Data("not json".utf8).write(to: url)
+        let store = ScanHistoryStore(fileURL: url)
+
+        #expect(store.loadAll().isEmpty)
+    }
+
+    @Test func clearRemovesFile() async throws {
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let store = ScanHistoryStore(fileURL: url)
+
+        store.append(makeEntry())
+        waitForBarrier(on: store)
+        #expect(store.loadAll().isEmpty == false)
+
+        store.clear()
+        waitForBarrier(on: store)
+        #expect(store.loadAll().isEmpty)
+    }
+}


### PR DESCRIPTION
Closes #53.

## Summary

Bundles three independent local-storage strategies in one PR. Together with
PR-E (Keychain) and PR-G (SwiftData), this covers rubric criterion 4 with
redundancy over the 20-point cap. Every persisted artifact lives under the
`diego.` namespace so it cannot collide with teammate-owned UserDefaults
keys, files, or k/v structures.

### D.1 — `@AppStorage` with `diego.` prefix (5 pts)
- `TripPlannerSheetView`: `diego.tripPlanner.preferredCurrency` (segmented
  picker COP / USD with a static 4000 conversion rate so the planner stays
  fully offline-friendly).
- `EditProfileView`: `diego.profile.showDemandBadgeOnDashboard` (toggle in
  a new Display preferences section).

### D.2 — Codable + FileManager scan history (5 pts)
- `Models/ScanHistoryEntry.swift`: Codable + Identifiable wrapper around
  `VehicleIdentification` plus a timestamp and the SHA256 image hash.
- `FileManagers/ScanHistoryStore.swift`: ring-buffer (max 50 entries)
  persisted to `Documents/diego.scan_history.json` via FileManager +
  JSONEncoder/JSONDecoder. Concurrent reader queue with barrier writes;
  atomic file I/O. Constructor accepts an optional fileURL/maxEntries for
  testability. Distinct from Mateo's `DiskPersistanceManager` — separate
  file, separate concurrency model, scan-specific API.
- `Views/Gerente/ScanHistorySheet.swift`: list view with empty-state
  placeholder.
- `VehicleAIScannerView` gets a topBarTrailing clock button that opens the
  history sheet, and `VehicleAIScannerViewModel.analyze` appends after
  every successful Gemini decode (sharing the SHA256 hex with PR-C's cache
  key).

### D.3 — KeyValueStore (hash-based) + ScanStats (5 pts)
- `FileManagers/KeyValueStore.swift`: generic
  `KeyValueStore<Key: Hashable & Codable, Value: Codable>` backed by a
  Swift Dictionary (O(1) lookups) with scope-namespaced JSON files under
  `Documents/diego.kv/`. Same rubric row as Mateo's `ArrayMap` (also a k/v
  store) but a deliberately different data structure: hash table vs
  parallel sorted arrays + binary search.
- `Core/ScanStats.swift`: `@MainActor` `ObservableObject` wrapping
  `KeyValueStore<String, Int>` for brand counts. Skips "unknown" / blank
  brands and emits `objectWillChange` on increment.
- `Profile.view.swift`: appended a "Top scanned brands" Section visible
  only to Gerentes, sourced from `ScanStats.shared.topBrands(3)`.
  Inserted between Settings and Logout without touching the rest of the
  (teammate-owned) view.

## Test plan

- [x] `xcodebuild` build_sim green on iPhone 17 (iOS 26.4).
- [x] `xcodebuild test` for `ScanHistoryStore`, `KeyValueStore`, and
      `ScanStats` suites all green.
- [x] Manual: TripPlanner toggle COP -> USD persists across app restart.
- [x] No teammate-owned persistence files (`DiskPersistanceManager`,
      `ArrayMap`, `UserRepository`, `AuthViewModel.biometricsEnabled`)
      modified.

## Notes for reviewers

`VehicleAIScannerViewModel.analyze` now hooks three local-storage actions in
sequence after a successful Gemini decode: NSCache write (from PR-C),
ScanHistoryStore append (D.2), and ScanStats.increment (D.3). All three are
best-effort and reuse the same SHA256 hash derived once at the top of the
function for the cache key.