### PR TITLE
feat(sprint3): KeychainHelper for Microsoft sign-in (PR-E)

### DIFF
--- a/sd-smart-parking/sd-smart-parking/Core/KeychainHelper.swift
+++ b/sd-smart-parking/sd-smart-parking/Core/KeychainHelper.swift
@@ -1,0 +1,103 @@
+//
+//  KeychainHelper.swift
+//  sd-smart-parking
+//
+//  Minimal wrapper over the Security framework. No third-party packages.
+//
+//  Stores items under kSecClassGenericPassword with
+//  kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly so credentials survive
+//  reboots but are NOT backed up to iCloud.
+//
+//  The KeychainStoring protocol is a justified extraction (per CLAUDE.md):
+//  unit tests inject InMemoryKeychain to avoid hitting the real keychain
+//  daemon, which would require simulator entitlements and produce flaky
+//  shared state across tests.
+//
+
+import Foundation
+import Security
+
+protocol KeychainStoring {
+    @discardableResult
+    func set(_ data: Data, account: String, service: String) -> Bool
+    func get(account: String, service: String) -> Data?
+    @discardableResult
+    func delete(account: String, service: String) -> Bool
+}
+
+enum KeychainHelper {
+    /// Default singleton wired to the real Security framework. Tests use
+    /// InMemoryKeychain instead.
+    static let live: KeychainStoring = LiveKeychain()
+}
+
+// MARK: - Live implementation
+
+private struct LiveKeychain: KeychainStoring {
+
+    func set(_ data: Data, account: String, service: String) -> Bool {
+        // Add does not update; delete first to make set behave as upsert.
+        _ = delete(account: account, service: service)
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: account,
+            kSecAttrService as String: service,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        ]
+        let status = SecItemAdd(query as CFDictionary, nil)
+        return status == errSecSuccess
+    }
+
+    func get(account: String, service: String) -> Data? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: account,
+            kSecAttrService as String: service,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess else { return nil }
+        return result as? Data
+    }
+
+    @discardableResult
+    func delete(account: String, service: String) -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: account,
+            kSecAttrService as String: service
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        return status == errSecSuccess || status == errSecItemNotFound
+    }
+}
+
+// MARK: - Convenience constants for the Microsoft sign-in flow
+
+enum MicrosoftKeychain {
+    static let service = "com.sdparking.microsoft"
+    static let accountUID = "uid"
+    static let accountEmail = "email"
+
+    static func saveCredentials(uid: String, email: String, store: KeychainStoring = KeychainHelper.live) {
+        if let uidData = uid.data(using: .utf8) {
+            store.set(uidData, account: accountUID, service: service)
+        }
+        if let emailData = email.data(using: .utf8) {
+            store.set(emailData, account: accountEmail, service: service)
+        }
+    }
+
+    static func lastEmail(store: KeychainStoring = KeychainHelper.live) -> String? {
+        guard let data = store.get(account: accountEmail, service: service) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    static func clearCredentials(store: KeychainStoring = KeychainHelper.live) {
+        store.delete(account: accountUID, service: service)
+        store.delete(account: accountEmail, service: service)
+    }
+}

--- a/sd-smart-parking/sd-smart-parking/ViewModels/AuthViewModel.swift
+++ b/sd-smart-parking/sd-smart-parking/ViewModels/AuthViewModel.swift
@@ -199,9 +199,16 @@ class AuthViewModel: ObservableObject {
             isLoading = true
             errorMessage = nil
         }
-        
+
         do {
             try await microsoftOAuth.signIn()
+
+            // Persist a "remember last Microsoft user" hint in Keychain so
+            // we can show a "Continue as <email>" caption on next launch.
+            // Best-effort: failures don't surface to the user.
+            if let user = Auth.auth().currentUser, let email = user.email {
+                MicrosoftKeychain.saveCredentials(uid: user.uid, email: email)
+            }
         } catch {
             await MainActor.run {
                 self.errorMessage = "Microsoft Sign-In was cancelled or failed."

--- a/sd-smart-parking/sd-smart-parking/Views/Login/LoginView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Login/LoginView.swift
@@ -126,6 +126,12 @@ struct LoginView: View {
                 .padding(.horizontal, 24)
 
                 // MARK: - Microsoft Button
+                if let lastEmail = MicrosoftKeychain.lastEmail() {
+                    Text("Last Microsoft user: \(lastEmail)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .padding(.horizontal, 24)
+                }
                 Button {
                     Task { await authVM.signInWithMicrosoft() }
                 } label: {

--- a/sd-smart-parking/sd-smart-parkingTests/KeychainHelperTests.swift
+++ b/sd-smart-parking/sd-smart-parkingTests/KeychainHelperTests.swift
@@ -1,0 +1,96 @@
+//
+//  KeychainHelperTests.swift
+//  sd-smart-parkingTests
+//
+//  Unit-tests the KeychainStoring abstraction against an InMemoryKeychain.
+//  We deliberately do NOT exercise the real Security framework here — that
+//  would require simulator entitlements and would leak state across tests.
+//  Manual verification against the live keychain happens via simctl reboot.
+//
+
+import Foundation
+import Testing
+@testable import sd_smart_parking
+
+private final class InMemoryKeychain: KeychainStoring {
+    private struct Key: Hashable { let account: String; let service: String }
+    private var items: [Key: Data] = [:]
+
+    func set(_ data: Data, account: String, service: String) -> Bool {
+        items[Key(account: account, service: service)] = data
+        return true
+    }
+
+    func get(account: String, service: String) -> Data? {
+        items[Key(account: account, service: service)]
+    }
+
+    @discardableResult
+    func delete(account: String, service: String) -> Bool {
+        items.removeValue(forKey: Key(account: account, service: service)) != nil
+    }
+}
+
+@Suite("KeychainHelper / InMemoryKeychain")
+struct KeychainHelperTests {
+
+    @Test func setThenGetReturnsSameBytes() async throws {
+        let store = InMemoryKeychain()
+        let payload = Data("hello".utf8)
+        #expect(store.set(payload, account: "uid", service: "svc.a"))
+        #expect(store.get(account: "uid", service: "svc.a") == payload)
+    }
+
+    @Test func setOverwritesExistingValue() async throws {
+        let store = InMemoryKeychain()
+        _ = store.set(Data("first".utf8), account: "uid", service: "svc.a")
+        _ = store.set(Data("second".utf8), account: "uid", service: "svc.a")
+        #expect(store.get(account: "uid", service: "svc.a") == Data("second".utf8))
+    }
+
+    @Test func deleteRemovesValue() async throws {
+        let store = InMemoryKeychain()
+        _ = store.set(Data("x".utf8), account: "uid", service: "svc.a")
+        #expect(store.delete(account: "uid", service: "svc.a"))
+        #expect(store.get(account: "uid", service: "svc.a") == nil)
+    }
+
+    @Test func differentServicesAreIsolated() async throws {
+        let store = InMemoryKeychain()
+        _ = store.set(Data("alpha".utf8), account: "uid", service: "svc.a")
+        _ = store.set(Data("beta".utf8), account: "uid", service: "svc.b")
+
+        #expect(store.get(account: "uid", service: "svc.a") == Data("alpha".utf8))
+        #expect(store.get(account: "uid", service: "svc.b") == Data("beta".utf8))
+    }
+}
+
+@Suite("MicrosoftKeychain")
+struct MicrosoftKeychainTests {
+
+    @Test func saveAndRetrieveEmail() async throws {
+        let store = InMemoryKeychain()
+        MicrosoftKeychain.saveCredentials(
+            uid: "diego-uid",
+            email: "diego@uniandes.edu.co",
+            store: store
+        )
+        #expect(MicrosoftKeychain.lastEmail(store: store) == "diego@uniandes.edu.co")
+    }
+
+    @Test func clearRemovesBothEntries() async throws {
+        let store = InMemoryKeychain()
+        MicrosoftKeychain.saveCredentials(uid: "u", email: "e@x.com", store: store)
+        MicrosoftKeychain.clearCredentials(store: store)
+        #expect(MicrosoftKeychain.lastEmail(store: store) == nil)
+        #expect(store.get(
+            account: MicrosoftKeychain.accountUID,
+            service: MicrosoftKeychain.service
+        ) == nil)
+    }
+
+    @Test func missingEmailReturnsNil() async throws {
+        let store = InMemoryKeychain()
+        #expect(MicrosoftKeychain.lastEmail(store: store) == nil)
+    }
+}


### PR DESCRIPTION
Closes #55.

## Summary

Persists the last Microsoft user's UID and email under the iOS Keychain so
the login screen can suggest "Last Microsoft user: <email>" on the next
launch. Built directly on the Security framework — no third-party packages.
Adds 5 declarable points of redundancy on rubric criterion 4 over the
20-point cap (PR-D already covers `@AppStorage`, Codable file, and a
hash-based K/V).

- `Core/KeychainHelper.swift`: `KeychainStoring` protocol plus a
  `LiveKeychain` implementation backed by `SecItemAdd` /
  `SecItemCopyMatching` / `SecItemDelete` with
  `kSecClassGenericPassword` and
  `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` (survives reboot, not
  iCloud-backed). Convenience `MicrosoftKeychain` enum exposes
  `saveCredentials` / `lastEmail` / `clearCredentials` with the
  `com.sdparking.microsoft` service namespace. Justified protocol
  extraction (per `CLAUDE.md`) lets tests inject `InMemoryKeychain`.
- `AuthViewModel.signInWithMicrosoft`: after a successful OAuth round-trip
  it pulls `Auth.auth().currentUser` and best-effort persists the uid
  and email through `MicrosoftKeychain.saveCredentials`. Failures stay
  silent — the login itself already succeeded. Email / Google /
  Biometrics paths untouched.
- `LoginView`: shows a small caption above the Microsoft button when
  `MicrosoftKeychain.lastEmail()` returns a value. No new env objects.
- `sd-smart-parkingTests/KeychainHelperTests.swift`: 7 `@Test` cases.
  `KeychainHelper / InMemoryKeychain` suite covers set/get round-trip,
  set-as-upsert, delete, and service isolation. `MicrosoftKeychain` suite
  covers saveCredentials/lastEmail round-trip, clearCredentials, and the
  empty-state nil return.

## Test plan

- [x] `xcodebuild` build_sim green.
- [x] `xcodebuild test` for `KeychainHelper / InMemoryKeychain` and
      `MicrosoftKeychain` suites green.
- [x] No teammate-owned auth code modified (Email / Google / Biometrics
      paths, `biometricsEnabled` `@AppStorage`).

## Notes for reviewers

The unit tests deliberately do **not** exercise the real Security framework
because that would require simulator entitlements and would leak state
across runs. Manual verification path:

1. Run on simulator, sign in with Microsoft.
2. `xcrun simctl shutdown booted && xcrun simctl boot ...` (reboot the sim).
3. Relaunch the app; the login screen should display "Last Microsoft user:
   &lt;your email&gt;" above the Microsoft button.