### PR TITLE
feat(sprint3): hand-rolled LRUCache for Trip Planner (PR-F)

### DIFF
--- a/sd-smart-parking/sd-smart-parking/Core/LRUCache.swift
+++ b/sd-smart-parking/sd-smart-parking/Core/LRUCache.swift
@@ -1,0 +1,99 @@
+//
+//  LRUCache.swift
+//  sd-smart-parking
+//
+//  Doubly-linked list + hash dictionary LRU cache. O(1) get and put,
+//  deterministic least-recently-used eviction when count > capacity.
+//
+//  This is the canonical implementation taught in data-structures courses;
+//  we hand-roll it instead of leaning on NSCache so the rubric defense can
+//  point to explicit choices for capacity, eviction policy, and complexity.
+//
+//  Distinct from the other cache structures in the project:
+//    - Core/SpotCacheManager.swift: NSCache (Juanes), implicit memory-pressure
+//      eviction, no count guarantee.
+//    - FileManagers/ArrayMap.swift: Mateo's parallel sorted arrays + binary
+//      search, O(log n) lookups, no eviction at all.
+//    - This LRUCache: hand-rolled doubly-linked list + Dictionary,
+//      capacity-bounded, O(1) lookups + writes, MRU-on-touch.
+//
+
+import Foundation
+
+final class LRUCache<Key: Hashable, Value> {
+
+    private final class Node {
+        let key: Key
+        var value: Value
+        var prev: Node?
+        var next: Node?
+        init(key: Key, value: Value) {
+            self.key = key
+            self.value = value
+        }
+    }
+
+    let capacity: Int
+    private var nodes: [Key: Node] = [:]
+    private var head: Node?  // MRU
+    private var tail: Node?  // LRU
+
+    init(capacity: Int) {
+        precondition(capacity > 0, "LRUCache capacity must be > 0")
+        self.capacity = capacity
+    }
+
+    var count: Int { nodes.count }
+
+    func get(_ key: Key) -> Value? {
+        guard let node = nodes[key] else { return nil }
+        moveToFront(node)
+        return node.value
+    }
+
+    func put(_ value: Value, for key: Key) {
+        if let existing = nodes[key] {
+            existing.value = value
+            moveToFront(existing)
+            return
+        }
+        let node = Node(key: key, value: value)
+        nodes[key] = node
+        addToFront(node)
+        if nodes.count > capacity, let lru = tail {
+            removeNode(lru)
+            nodes.removeValue(forKey: lru.key)
+        }
+    }
+
+    func clear() {
+        nodes.removeAll()
+        head = nil
+        tail = nil
+    }
+
+    // MARK: - List operations
+
+    private func addToFront(_ node: Node) {
+        node.prev = nil
+        node.next = head
+        head?.prev = node
+        head = node
+        if tail == nil { tail = node }
+    }
+
+    private func removeNode(_ node: Node) {
+        node.prev?.next = node.next
+        node.next?.prev = node.prev
+        if node === head { head = node.next }
+        if node === tail { tail = node.prev }
+        node.prev = nil
+        node.next = nil
+    }
+
+    private func moveToFront(_ node: Node) {
+        guard node !== head else { return }
+        removeNode(node)
+        addToFront(node)
+    }
+}

--- a/sd-smart-parking/sd-smart-parking/Models/TripCacheKey.swift
+++ b/sd-smart-parking/sd-smart-parking/Models/TripCacheKey.swift
@@ -1,0 +1,29 @@
+//
+//  TripCacheKey.swift
+//  sd-smart-parking
+//
+//  Composite key for caching computed trip costs in the LRUCache.
+//
+//  Uses 5-minute buckets on both arrival and duration so small slider
+//  adjustments still produce cache hits — keying on the raw Date would mean
+//  the cache only ever pegs on identical user clicks, which never happens
+//  via a continuous DatePicker.
+//
+
+import Foundation
+
+struct TripCacheKey: Hashable {
+    let arrivalBucket: Int
+    let durationBucket: Int
+
+    /// Five-minute buckets — picked because the DatePicker's minute step is
+    /// usually 1 or 5, so a 5-minute window absorbs the typical jitter and
+    /// is small enough that the cached cost is still a faithful approximation.
+    static let arrivalBucketSeconds: TimeInterval = 300.0
+    static let durationBucketsPerHour: Double = 12.0
+
+    init(arrivalDate: Date, durationHours: Double) {
+        self.arrivalBucket = Int(arrivalDate.timeIntervalSince1970 / Self.arrivalBucketSeconds)
+        self.durationBucket = Int((durationHours * Self.durationBucketsPerHour).rounded())
+    }
+}

--- a/sd-smart-parking/sd-smart-parking/ViewModels/TripPlannerViewModel.swift
+++ b/sd-smart-parking/sd-smart-parking/ViewModels/TripPlannerViewModel.swift
@@ -17,6 +17,11 @@ class TripPlannerViewModel: ObservableObject {
 
     private let store: CalendarEventStoring
 
+    /// Capacity = 5: a typical user explores 2-3 alternative arrival/duration
+    /// combinations before locking in a plan. 5 leaves headroom without
+    /// holding stale entries forever.
+    private let costCache = LRUCache<TripCacheKey, Double>(capacity: 5)
+
     init(store: CalendarEventStoring = EKEventStore()) {
         self.store = store
         let calendar = Calendar.current
@@ -91,7 +96,11 @@ class TripPlannerViewModel: ObservableObject {
     // MARK: - Cost
 
     func estimatedCost() -> Double {
-        ParkingConfig.calculateFee(hours: durationHours, currentDayTotal: 0)
+        let key = TripCacheKey(arrivalDate: arrivalDate, durationHours: durationHours)
+        if let cached = costCache.get(key) { return cached }
+        let cost = ParkingConfig.calculateFee(hours: durationHours, currentDayTotal: 0)
+        costCache.put(cost, for: key)
+        return cost
     }
 
     // MARK: - Calendar Export

--- a/sd-smart-parking/sd-smart-parkingTests/LRUCacheTests.swift
+++ b/sd-smart-parking/sd-smart-parkingTests/LRUCacheTests.swift
@@ -1,0 +1,110 @@
+//
+//  LRUCacheTests.swift
+//  sd-smart-parkingTests
+//
+
+import Foundation
+import Testing
+@testable import sd_smart_parking
+
+@Suite("LRUCache")
+struct LRUCacheTests {
+
+    @Test func emptyCacheReturnsNil() async throws {
+        let c = LRUCache<String, Int>(capacity: 5)
+        #expect(c.get("anything") == nil)
+        #expect(c.count == 0)
+    }
+
+    @Test func putThenGetReturnsValue() async throws {
+        let c = LRUCache<String, Int>(capacity: 5)
+        c.put(42, for: "answer")
+        #expect(c.get("answer") == 42)
+        #expect(c.count == 1)
+    }
+
+    @Test func putUpdatesExistingValueWithoutGrowingCount() async throws {
+        let c = LRUCache<String, Int>(capacity: 5)
+        c.put(1, for: "k")
+        c.put(99, for: "k")
+        #expect(c.get("k") == 99)
+        #expect(c.count == 1)
+    }
+
+    @Test func capacityOverflowEvictsLeastRecentlyUsed() async throws {
+        let c = LRUCache<String, Int>(capacity: 2)
+        c.put(1, for: "a")
+        c.put(2, for: "b")
+        c.put(3, for: "c") // evicts "a"
+
+        #expect(c.get("a") == nil)
+        #expect(c.get("b") == 2)
+        #expect(c.get("c") == 3)
+        #expect(c.count == 2)
+    }
+
+    @Test func getPromotesEntryToMostRecentlyUsed() async throws {
+        let c = LRUCache<String, Int>(capacity: 2)
+        c.put(1, for: "a")
+        c.put(2, for: "b")
+        _ = c.get("a")        // promotes "a" -> MRU; "b" is now LRU
+        c.put(3, for: "c")    // evicts "b"
+
+        #expect(c.get("b") == nil)
+        #expect(c.get("a") == 1)
+        #expect(c.get("c") == 3)
+    }
+
+    @Test func clearRemovesEverything() async throws {
+        let c = LRUCache<String, Int>(capacity: 3)
+        c.put(1, for: "a"); c.put(2, for: "b"); c.put(3, for: "c")
+        c.clear()
+        #expect(c.count == 0)
+        #expect(c.get("a") == nil)
+        #expect(c.get("c") == nil)
+    }
+
+    @Test func capacityOneAlwaysHoldsLatest() async throws {
+        let c = LRUCache<String, Int>(capacity: 1)
+        c.put(1, for: "a")
+        c.put(2, for: "b")
+        c.put(3, for: "c")
+        #expect(c.count == 1)
+        #expect(c.get("c") == 3)
+        #expect(c.get("a") == nil)
+    }
+}
+
+@Suite("TripCacheKey")
+struct TripCacheKeyTests {
+
+    @Test func smallArrivalDifferenceLandsInSameBucket() async throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let later = now.addingTimeInterval(60) // +1 minute
+        let k1 = TripCacheKey(arrivalDate: now, durationHours: 1.0)
+        let k2 = TripCacheKey(arrivalDate: later, durationHours: 1.0)
+        #expect(k1 == k2) // same 5-min bucket
+    }
+
+    @Test func crossingBucketBoundaryProducesDifferentKey() async throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let later = now.addingTimeInterval(301) // +5 min 1 sec
+        let k1 = TripCacheKey(arrivalDate: now, durationHours: 1.0)
+        let k2 = TripCacheKey(arrivalDate: later, durationHours: 1.0)
+        #expect(k1 != k2)
+    }
+
+    @Test func smallDurationDifferenceLandsInSameBucket() async throws {
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let k1 = TripCacheKey(arrivalDate: date, durationHours: 1.00)
+        let k2 = TripCacheKey(arrivalDate: date, durationHours: 1.04) // +2.4 min
+        #expect(k1 == k2)
+    }
+
+    @Test func differentDurationsProduceDifferentKeys() async throws {
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let k1 = TripCacheKey(arrivalDate: date, durationHours: 1.0)
+        let k2 = TripCacheKey(arrivalDate: date, durationHours: 1.5)
+        #expect(k1 != k2)
+    }
+}


### PR DESCRIPTION
Closes #57.

## Summary

Adds an explicit doubly-linked list + dictionary LRU cache and wires it into
`TripPlannerViewModel.estimatedCost()` so re-evaluating the same
arrival/duration combination is O(1) instead of recomputing through
`ParkingConfig.calculateFee`. Closes Diego's individual coverage of rubric
criterion 6 (10 + 10 = 20 pts).

Deliberately a third caching strategy in the project:
- `SpotCacheManager` (Juanes): NSCache, implicit memory-pressure eviction.
- `ArrayMap` (Mateo): parallel sorted arrays, O(log n), no eviction.
- `LRUCache` (this PR): hand-rolled doubly-linked list + Dictionary,
  capacity-bounded, deterministic LRU eviction, O(1) get + put.

- `Core/LRUCache.swift`: generic `final class` with `Node` plus head / tail
  pointers, `addToFront` / `removeNode` / `moveToFront` helpers, and a
  precondition that capacity > 0.
- `Models/TripCacheKey.swift`: composite `Hashable` key with 5-minute
  arrival buckets and 12-buckets-per-hour duration buckets so small slider
  adjustments still hit the cache. Bucket constants exposed as static lets
  so tests and future tuning can reference them.
- `TripPlannerViewModel`: holds a private
  `LRUCache<TripCacheKey, Double>` with capacity 5 (typical user explores
  2-3 alternatives). `estimatedCost()` now does cache lookup -> compute on
  miss -> write back.
- `LRUCacheTests`: 7 `@Test` cases for empty / put-get /
  update-existing / capacity overflow eviction / MRU promotion on get /
  clear / capacity-1 always holds latest. `TripCacheKey` tests verify
  same bucket for sub-5-min jitter and different buckets across
  boundaries for both arrival and duration.

## Test plan

- [x] `xcodebuild` build_sim green.
- [x] `xcodebuild test` for `LRUCache`, `TripCacheKey`, and the
      existing `TripPlannerViewModel` suite green (so the cache
      integration did not break the existing computed-cost contract).
- [x] No teammate-owned cache files (`SpotCacheManager`, `ArrayMap`)
      modified.

## Notes for reviewers

The hand-rolled implementation is intentional even though `NSCache` exists,
because the rubric asks for explicit reasoning about parameters and
eviction. The cache lives as a private property on the VM so each sheet
presentation gets its own cache (no cross-session leakage).