### PR TITLE
:bug: fix(sprint3): pre-defense fix batch — offline guards, cache history, re-export, profile toggle

### DIFF
--- a/sd-smart-parking/sd-smart-parking/ViewModels/TripPlannerViewModel.swift
+++ b/sd-smart-parking/sd-smart-parking/ViewModels/TripPlannerViewModel.swift
@@ -121,6 +121,12 @@ class TripPlannerViewModel: ObservableObject {
     // MARK: - Calendar Export
 
     func exportTrip(parkingName: String, closingHour: Int) async {
+        // Reset the one-shot event flag so `.onChange(of: tripVM.didExport)` in
+        // TripPlannerSheetView fires on every successful export. Without this,
+        // a second consecutive Add-to-Calendar tap would not insert another
+        // SavedTripPlan because `.onChange(of:)` only fires on transitions.
+        await MainActor.run { didExport = false }
+
         let status = store.authorizationStatus(for: .event)
 
         switch status {

--- a/sd-smart-parking/sd-smart-parking/ViewModels/VehicleAIScannerViewModel.swift
+++ b/sd-smart-parking/sd-smart-parking/ViewModels/VehicleAIScannerViewModel.swift
@@ -22,8 +22,24 @@ class VehicleAIScannerViewModel: ObservableObject {
     @Published var state: ScanState = .idle
 
     private let model: GenerativeModel
+    private let cache: AIScanCache
+    private let history: ScanHistoryStore
+    private let stats: ScanStats
 
-    init() {
+    /// Dependencies default to the shared singletons in production. Tests
+    /// inject fresh instances to keep the cache HIT path deterministic.
+    /// Optional + nil-coalesce keeps the default parameter expression out of
+    /// a nonisolated synthesized context (the @MainActor `ScanStats.shared`
+    /// would otherwise warn under stricter concurrency).
+    init(
+        cache: AIScanCache? = nil,
+        history: ScanHistoryStore? = nil,
+        stats: ScanStats? = nil
+    ) {
+        self.cache = cache ?? .shared
+        self.history = history ?? .shared
+        self.stats = stats ?? .shared
+
         let safetySettings = [
             SafetySetting(harmCategory: .harassment, threshold: .blockNone),
             SafetySetting(harmCategory: .dangerousContent, threshold: .blockNone)
@@ -50,8 +66,12 @@ class VehicleAIScannerViewModel: ObservableObject {
         // Cache lookup — saves a Gemini round-trip when the operator re-scans
         // the exact same vehicle photo (same JPEG bytes -> same SHA256 key).
         let cacheKey = preparedJPEG.map { AIScanCache.key(forJPEGData: $0) }
-        if let key = cacheKey, let cached = AIScanCache.shared.get(key) {
+        if let key = cacheKey, let cached = cache.get(key) {
             state = .success(cached)
+            // History + stats must run on HIT too, otherwise re-scanning the
+            // same vehicle drops the entry from local history and skews the
+            // top-brands counter.
+            recordSuccess(cached, hashHex: key as String)
             return
         }
 
@@ -67,19 +87,11 @@ class VehicleAIScannerViewModel: ObservableObject {
 
                 // Cache write — only if we have a stable key and JPEG bytes.
                 if let key = cacheKey, let data = preparedJPEG {
-                    AIScanCache.shared.put(identification, for: key, cost: data.count)
+                    cache.put(identification, for: key, cost: data.count)
                 }
 
-                // Append to local scan history (Codable + FileManager). Best-effort
-                // write — failures don't surface to the user. Reuses the same
-                // SHA256 hex string the cache key already derived from the bytes.
                 let hashHex = (cacheKey as String?) ?? ""
-                ScanHistoryStore.shared.append(
-                    ScanHistoryEntry(identification: identification, imageHashHex: hashHex)
-                )
-
-                // Update brand stats (KeyValueStore). Ignored for "unknown".
-                ScanStats.shared.increment(brand: identification.brand)
+                recordSuccess(identification, hashHex: hashHex)
             } catch let decodingError as VehicleAIScannerError {
                 self.state = .failure(decodingError.message)
             } catch {
@@ -90,6 +102,18 @@ class VehicleAIScannerViewModel: ObservableObject {
 
     func reset() {
         state = .idle
+    }
+
+    // MARK: - Private
+
+    /// Persists a successful identification into local history (Codable+FileManager)
+    /// and brand stats (KeyValueStore). Reused by BOTH cache HIT and Gemini MISS
+    /// branches so re-scans keep both stores in sync.
+    private func recordSuccess(_ identification: VehicleIdentification, hashHex: String) {
+        history.append(
+            ScanHistoryEntry(identification: identification, imageHashHex: hashHex)
+        )
+        stats.increment(brand: identification.brand)
     }
 
     // MARK: - Helpers

--- a/sd-smart-parking/sd-smart-parking/Views/Login/LoginView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Login/LoginView.swift
@@ -86,8 +86,9 @@ struct LoginView: View {
                     .background(email.isEmpty || password.count < 4 ? Color.gray : Color.blue)
                     .foregroundColor(.white)
                     .cornerRadius(15)
+                    .opacity(networkMonitor.isConnected ? 1.0 : 0.45)
                 }
-                .disabled(authVM.isLoading || email.isEmpty || password.count < 4)
+                .disabled(!networkMonitor.isConnected || authVM.isLoading || email.isEmpty || password.count < 4)
                 .padding(.horizontal, 24)
 
                 // MARK: - Divider
@@ -121,8 +122,10 @@ struct LoginView: View {
                             .stroke(Color.gray.opacity(0.2), lineWidth: 1)
                     )
                     .shadow(color: Color.black.opacity(0.05), radius: 3, x: 0, y: 2)
+                    .opacity(networkMonitor.isConnected ? 1.0 : 0.45)
                 }
                 .contentShape(Rectangle())
+                .disabled(!networkMonitor.isConnected || authVM.isLoading)
                 .padding(.horizontal, 24)
 
                 // MARK: - Microsoft Button
@@ -161,7 +164,7 @@ struct LoginView: View {
                 .padding(.horizontal, 24)
 
                 if !networkMonitor.isConnected {
-                    Text("Sin conexión — usa Face ID si tienes sesión guardada")
+                    Text("Sin conexión — los métodos online están deshabilitados. Usa Face ID si tienes sesión guardada.")
                         .font(.caption)
                         .foregroundColor(.secondary)
                         .padding(.horizontal, 24)

--- a/sd-smart-parking/sd-smart-parking/Views/Usuario/Dashboard/ParkingDemandInsightsView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Usuario/Dashboard/ParkingDemandInsightsView.swift
@@ -24,6 +24,13 @@ struct ParkingDemandInsightsView: View {
     @EnvironmentObject private var networkMonitor: NetworkMonitor
     @State private var bucket: Bucket
 
+    /// Read-side mirror of the EditProfile toggle that the user owns. When off
+    /// the sheet collapses to a `ContentUnavailableView` so the dashboard's
+    /// banner trigger remains intact (Mateo's territory) without breaking
+    /// the user's stated preference.
+    @AppStorage("diego.profile.showDemandBadgeOnDashboard")
+    private var showDemandBadge: Bool = true
+
     enum Bucket: String, CaseIterable, Identifiable {
         case weekday = "Weekdays"
         case weekend = "Weekends"
@@ -94,48 +101,16 @@ struct ParkingDemandInsightsView: View {
 
     var body: some View {
         NavigationStack {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 20) {
-                    Picker("Day type", selection: $bucket) {
-                        ForEach(Bucket.allCases) { b in Text(b.rawValue).tag(b) }
-                    }
-                    .pickerStyle(.segmented)
-                    .padding(.horizontal, 16)
-                    .padding(.top, 8)
-
-                    sampleSizeCaption
-
-                    chartCard(
-                        title: "Arrivals per hour",
-                        caption: "How many cars enter each hour historically",
-                        data: entryCounts,
-                        color: .blue
-                    )
-
-                    chartCard(
-                        title: "Departures per hour",
-                        caption: "How many cars leave each hour historically",
-                        data: exitCounts,
-                        color: .purple
-                    )
-
-                    recommendationCard(
-                        title: "Best times to arrive",
-                        subtitle: "Hours with the fewest recorded arrivals — easiest to find a spot",
-                        icon: "arrow.down.circle.fill",
-                        tint: .green,
-                        hours: bestEntryHours
-                    )
-
-                    recommendationCard(
-                        title: "Best times to leave",
-                        subtitle: "Hours with the fewest recorded departures — avoid the exit rush",
-                        icon: "arrow.up.circle.fill",
-                        tint: .indigo,
-                        hours: bestExitHours
+            Group {
+                if showDemandBadge {
+                    insightsScroll
+                } else {
+                    ContentUnavailableView(
+                        "Insights hidden",
+                        systemImage: "eye.slash",
+                        description: Text("Re-enable from Profile → Edit Profile.")
                     )
                 }
-                .padding(.bottom, 24)
             }
             .background(Color(.systemGroupedBackground))
             .navigationTitle("Parking Insights")
@@ -148,6 +123,52 @@ struct ParkingDemandInsightsView: View {
         }
     }
 
+    private var insightsScroll: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                Picker("Day type", selection: $bucket) {
+                    ForEach(Bucket.allCases) { b in Text(b.rawValue).tag(b) }
+                }
+                .pickerStyle(.segmented)
+                .padding(.horizontal, 16)
+                .padding(.top, 8)
+
+                sampleSizeCaption
+
+                chartCard(
+                    title: "Arrivals per hour",
+                    caption: "How many cars enter each hour historically",
+                    data: entryCounts,
+                    color: .blue
+                )
+
+                chartCard(
+                    title: "Departures per hour",
+                    caption: "How many cars leave each hour historically",
+                    data: exitCounts,
+                    color: .purple
+                )
+
+                recommendationCard(
+                    title: "Best times to arrive",
+                    subtitle: "Hours with the fewest recorded arrivals — easiest to find a spot",
+                    icon: "arrow.down.circle.fill",
+                    tint: .green,
+                    hours: bestEntryHours
+                )
+
+                recommendationCard(
+                    title: "Best times to leave",
+                    subtitle: "Hours with the fewest recorded departures — avoid the exit rush",
+                    icon: "arrow.up.circle.fill",
+                    tint: .indigo,
+                    hours: bestExitHours
+                )
+            }
+            .padding(.bottom, 24)
+        }
+    }
+
     // MARK: - Pieces
 
     @ViewBuilder
@@ -157,7 +178,13 @@ struct ParkingDemandInsightsView: View {
             ? "No historic records for \(bucket.rawValue.lowercased()) yet. Come back after a few days of activity."
             : "Based on \(totals.entries) arrivals and \(totals.exits) departures recorded on \(bucket.rawValue.lowercased())."
         VStack(alignment: .leading, spacing: 6) {
-            if !networkMonitor.isConnected, let synced = lastSyncedAt {
+            // TODO: replace `lastSyncedAt` source with a dedicated
+            // `ParkingViewModel.lastFetchedAt: Date?`. Today the dashboard call
+            // site passes `vehicleRecords.first?.timestamp`, which only works
+            // while that array is sorted DESC and non-empty.
+            if !networkMonitor.isConnected && lastSyncedAt == nil {
+                OfflineNoticeBadge(message: "Sin conexión — sin datos sincronizados")
+            } else if !networkMonitor.isConnected, let synced = lastSyncedAt {
                 Text("Sin conexión — mostrando datos al \(Self.lastSyncedFormatter.string(from: synced)).")
                     .font(.footnote.weight(.semibold))
                     .foregroundColor(.orange)

--- a/sd-smart-parking/sd-smart-parkingTests/TripPlannerViewModelTests.swift
+++ b/sd-smart-parking/sd-smart-parkingTests/TripPlannerViewModelTests.swift
@@ -3,6 +3,7 @@
 //  sd-smart-parkingTests
 //
 
+import Combine
 import EventKit
 import Foundation
 import Testing
@@ -189,5 +190,33 @@ struct TripPlannerExportTests {
 
         #expect(mock.savedEvent == nil)
         #expect(vm.alertTitle == "Calendar Access Denied")
+    }
+
+    @Test func consecutiveExports_dipDidExportThroughFalse() async {
+        // Regression guard: TripPlannerSheetView listens via
+        // `.onChange(of: tripVM.didExport)` and only inserts a SavedTripPlan
+        // when the flag transitions false → true. If `exportTrip` does not
+        // reset the flag at the top, the second consecutive Add-to-Calendar
+        // tap silently drops the SwiftData write.
+        let mock = MockCalendarStore()
+        mock.statusToReturn = .writeOnly
+        let vm = TripPlannerViewModel(store: mock)
+        vm.arrivalDate = makeDate(hour: 10)
+        vm.leaveDate = makeDate(hour: 12)
+
+        await vm.exportTrip(parkingName: "X", closingHour: 22)
+        #expect(vm.didExport)
+
+        var emissions: [Bool] = []
+        let cancellable = vm.$didExport.sink { emissions.append($0) }
+
+        await vm.exportTrip(parkingName: "X", closingHour: 22)
+        cancellable.cancel()
+
+        // Initial replay of `true`, then `false` from the reset at the top
+        // of exportTrip, then `true` again when saveTrip completes.
+        #expect(emissions.first == true)
+        #expect(emissions.contains(false))
+        #expect(emissions.last == true)
     }
 }

--- a/sd-smart-parking/sd-smart-parkingTests/VehicleAIScannerViewModelTests.swift
+++ b/sd-smart-parking/sd-smart-parkingTests/VehicleAIScannerViewModelTests.swift
@@ -1,0 +1,157 @@
+//
+//  VehicleAIScannerViewModelTests.swift
+//  sd-smart-parkingTests
+//
+//  Covers the cache HIT path of `VehicleAIScannerViewModel.analyze`. The MISS
+//  path goes through Gemini and is exercised manually in the simulator; here we
+//  inject fresh AIScanCache / ScanHistoryStore / ScanStats instances so the HIT
+//  branch stays a pure synchronous, deterministic test.
+//
+
+import Foundation
+import Testing
+import UIKit
+@testable import sd_smart_parking
+
+@MainActor
+@Suite("VehicleAIScannerViewModelCacheHit")
+struct VehicleAIScannerViewModelCacheHitTests {
+
+    // MARK: - Fixtures
+
+    private func makeImage(width: Int = 80, height: Int = 80, color: UIColor = .red) -> UIImage {
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: width, height: height))
+        return renderer.image { ctx in
+            color.setFill()
+            ctx.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        }
+    }
+
+    private func makeIdentification(brand: String = "toyota", plate: String = "ABC123") -> VehicleIdentification {
+        VehicleIdentification(
+            plate: plate,
+            plateVisible: true,
+            color: "white",
+            brand: brand,
+            model: "corolla"
+        )
+    }
+
+    /// Returns the SHA256 key the VM will compute for a given image (after the
+    /// same resize-to-1280 + JPEG(0.7) pipeline). Pre-populating the cache with
+    /// this key forces the HIT branch.
+    private func cacheKey(for image: UIImage) -> NSString {
+        let resized = resize(image, maxSide: 1280)
+        let jpeg = resized.jpegData(compressionQuality: 0.7)!
+        return AIScanCache.key(forJPEGData: jpeg)
+    }
+
+    private func resize(_ image: UIImage, maxSide: CGFloat) -> UIImage {
+        let size = image.size
+        let longest = max(size.width, size.height)
+        guard longest > maxSide else { return image }
+        let scale = maxSide / longest
+        let newSize = CGSize(width: size.width * scale, height: size.height * scale)
+        let renderer = UIGraphicsImageRenderer(size: newSize)
+        return renderer.image { _ in image.draw(in: CGRect(origin: .zero, size: newSize)) }
+    }
+
+    private func tempHistoryURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("ai-scanner-vm-test-\(UUID().uuidString).json")
+    }
+
+    private func waitForBarrier(on store: ScanHistoryStore) {
+        // loadAll() shares the concurrent queue with the barrier write, so
+        // calling it forces every preceding append to flush first.
+        _ = store.loadAll()
+    }
+
+    // MARK: - Tests
+
+    @Test func cacheHitAppendsToHistory() async throws {
+        let cache = AIScanCache()
+        let historyURL = tempHistoryURL()
+        defer { try? FileManager.default.removeItem(at: historyURL) }
+        let history = ScanHistoryStore(fileURL: historyURL)
+        let stats = ScanStats(store: KeyValueStore<String, Int>(scope: "vmtest-history-\(UUID().uuidString)"))
+        let vm = VehicleAIScannerViewModel(cache: cache, history: history, stats: stats)
+
+        let image = makeImage()
+        let key = cacheKey(for: image)
+        let id = makeIdentification(plate: "HIT001")
+        cache.put(id, for: key, cost: 1024)
+
+        vm.analyze(image: image)
+
+        // HIT branch is fully synchronous — no Task involved.
+        if case let .success(returned) = vm.state {
+            #expect(returned == id)
+        } else {
+            Issue.record("Expected .success state after cache HIT, got \(vm.state)")
+        }
+
+        waitForBarrier(on: history)
+        let entries = history.loadAll()
+        #expect(entries.count == 1)
+        #expect(entries.first?.identification.plate == "HIT001")
+        #expect(entries.first?.imageHashHex == key as String)
+
+        stats.reset()
+    }
+
+    @Test func cacheHitIncrementsStats() async throws {
+        let cache = AIScanCache()
+        let historyURL = tempHistoryURL()
+        defer { try? FileManager.default.removeItem(at: historyURL) }
+        let history = ScanHistoryStore(fileURL: historyURL)
+        let stats = ScanStats(store: KeyValueStore<String, Int>(scope: "vmtest-stats-\(UUID().uuidString)"))
+        let vm = VehicleAIScannerViewModel(cache: cache, history: history, stats: stats)
+
+        let image = makeImage(color: .blue)
+        let key = cacheKey(for: image)
+        let id = makeIdentification(brand: "mazda", plate: "HIT002")
+        cache.put(id, for: key, cost: 1024)
+
+        vm.analyze(image: image)
+        vm.analyze(image: image)
+
+        let top = stats.topBrands(5)
+        let mazdaCount = top.first { $0.brand == "mazda" }?.count
+        #expect(mazdaCount == 2)
+
+        stats.reset()
+    }
+
+    @Test func cacheHitDoesNotAppendOnMissingKey() async throws {
+        // Sanity check: if the cache lookup misses, the HIT branch is skipped,
+        // so analyze launches a Gemini Task instead. We cannot fully exercise
+        // that here without a real network; we only assert that no history is
+        // written synchronously when the cache is empty.
+        let cache = AIScanCache()
+        let historyURL = tempHistoryURL()
+        defer { try? FileManager.default.removeItem(at: historyURL) }
+        let history = ScanHistoryStore(fileURL: historyURL)
+        let stats = ScanStats(store: KeyValueStore<String, Int>(scope: "vmtest-miss-\(UUID().uuidString)"))
+        let vm = VehicleAIScannerViewModel(cache: cache, history: history, stats: stats)
+
+        let image = makeImage(color: .green)
+
+        vm.analyze(image: image)
+
+        // Synchronously after analyze returns we should be in .analyzing,
+        // because the MISS branch kicked off a Task and is awaiting Gemini.
+        if case .analyzing = vm.state {
+            // expected
+        } else {
+            Issue.record("Expected .analyzing state after cache MISS, got \(vm.state)")
+        }
+
+        waitForBarrier(on: history)
+        // Nothing flushed to history yet — that only happens after Gemini
+        // returns, which won't happen in the test environment.
+        #expect(history.loadAll().isEmpty)
+
+        stats.reset()
+    }
+}


### PR DESCRIPTION
Closes #62.

## Summary

Five rubric-impacting fixes batched into one PR before the Sprint 3 oral defense. Covers gaps in criteria 4 (Local Storage), 5 (Eventual Connectivity), and 6 (Caching) found during the cross-review documented in `docs/sprint-3/pr-review-findings.md` (§ 1).

## What changed

- **`Views/Usuario/Dashboard/ParkingDemandInsightsView.swift`**
  - Cold-start fallback: when `!networkMonitor.isConnected && lastSyncedAt == nil` the sheet now renders an `OfflineNoticeBadge`. The previous guard required a non-nil `lastSyncedAt` and showed nothing on first launch without network.
  - AppStorage reader for `diego.profile.showDemandBadgeOnDashboard`. The EditProfile toggle had no consumer; the sheet now collapses to a `ContentUnavailableView` ("Insights hidden — re-enable from Profile → Edit Profile") when the toggle is off, leaving the dashboard banner trigger (Mateo's territory) untouched.
  - Inline `// TODO:` documenting the call site's reliance on `vehicleRecords.first?.timestamp` ordering invariant — the proper fix would expose `lastFetchedAt: Date?` from `ParkingViewModel` (deferred since that file is teammate-owned).

- **`Views/Login/LoginView.swift`** — Email/Password and Google buttons get the same `.disabled(!networkMonitor.isConnected || ...)` + `.opacity(networkMonitor.isConnected ? 1.0 : 0.45)` treatment Microsoft already had. Offline caption rewritten to be method-agnostic ("Sin conexión — los métodos online están deshabilitados. Usa Face ID si tienes sesión guardada.").

- **`ViewModels/VehicleAIScannerViewModel.swift`** — extracted `private func recordSuccess(_:hashHex:)` that appends to `ScanHistoryStore` and increments `ScanStats`. Called from BOTH the cache HIT branch (after `state = .success(cached)`) and the Gemini MISS branch. `init` now accepts optional injectable `cache` / `history` / `stats` defaulting to the shared singletons via nil-coalesce — keeps the @MainActor `ScanStats.shared` out of a nonisolated default-parameter context and exposes the seam the new test suite needs.

- **`ViewModels/TripPlannerViewModel.swift`** — `exportTrip(parkingName:closingHour:)` resets `didExport = false` (via `await MainActor.run`) before any auth or save work. Without that reset, the `.onChange(of: tripVM.didExport)` in `TripPlannerSheetView` did not re-fire on consecutive Add-to-Calendar taps and the second `SavedTripPlan` was silently dropped.

## Test plan

- [x] `XcodeBuildMCP build_sim` (sd-smart-parking on iPhone 17 / iOS 26.4) — clean, 0 new warnings.
- [x] `XcodeBuildMCP test_sim` — 166/166 passing (162 baseline + 4 new):
  - `VehicleAIScannerViewModelCacheHitTests.cacheHitAppendsToHistory`
  - `VehicleAIScannerViewModelCacheHitTests.cacheHitIncrementsStats`
  - `VehicleAIScannerViewModelCacheHitTests.cacheHitDoesNotAppendOnMissingKey`
  - `TripPlannerCalendarExport.consecutiveExports_dipDidExportThroughFalse`
- [x] Manual: Cold-start sim offline → Dashboard → Demand Insights → `OfflineNoticeBadge` visible inside the sheet.
- [x] Manual: Profile → Edit Profile toggles `Show Demand Badge on Dashboard` off → reopening Demand Insights shows `ContentUnavailableView`.
- [x] Manual: Login offline → Email Login, Google, Microsoft all disabled (Face ID still tappable). Caption uses the new generic Spanish text.
- [x] Manual: Gerente AI Scan same vehicle photo twice → both entries appear in history; brand counter increments by 2.
- [x] Manual: Trip Planner → Add to Calendar → dismiss → re-open Trip Planner → Add to Calendar again → both entries visible in `TripHistoryView`.