### PR TITLE
:bug: fix(sprint3): persist parking prefs in UserDefaults + gate Microsoft auto sign-in

### DIFF
--- a/sd-smart-parking/sd-smart-parking/ViewModels/AuthViewModel.swift
+++ b/sd-smart-parking/sd-smart-parking/ViewModels/AuthViewModel.swift
@@ -34,7 +34,20 @@ class AuthViewModel: ObservableObject {
     @Published var isGerente: Bool = false
     @Published var currentUserEmail: String? = nil
     @Published var requiresBiometricUnlock: Bool = false
-    
+
+    /// True when a Microsoft session is cached in Firebase but the user has
+    /// NOT yet explicitly tapped the Microsoft button in this app launch.
+    /// LoginView observes this to swap the button into a "Continue as <email>"
+    /// confirmation, instead of letting the auth-state listener auto-route
+    /// straight into the app.
+    @Published var pendingMicrosoftAutoLogin: Bool = false
+
+    /// Gate consumed by the auth-state listener: only after the user has
+    /// explicitly chosen to proceed with the cached Microsoft session (or
+    /// completed a fresh sign-in) do we let the listener route into the app.
+    /// Resets each app launch because it lives in instance state.
+    private var allowMicrosoftAutoEntry: Bool = false
+
     @AppStorage("biometricsEnabled") var biometricsEnabled: Bool = false
     
     // The biometric type available on this device (.faceID, .touchID, or .none)
@@ -61,6 +74,22 @@ class AuthViewModel: ObservableObject {
         authStateListener = Auth.auth().addStateDidChangeListener { [weak self] _, firebaseUser in
             guard let self else { return }
             if let firebaseUser = firebaseUser {
+                // Gate cached Microsoft sessions: even though Firebase has a
+                // valid persisted credential, we keep the user on LoginView
+                // until they explicitly tap the Microsoft button. This gives
+                // them the option to switch to another provider on every
+                // launch instead of being silently auto-routed into the app.
+                let isMicrosoftSession = firebaseUser.providerData
+                    .contains { $0.providerID == "microsoft.com" }
+                if isMicrosoftSession && !self.allowMicrosoftAutoEntry {
+                    DispatchQueue.main.async {
+                        self.pendingMicrosoftAutoLogin = true
+                        self.currentUserEmail = firebaseUser.email
+                        self.isLoggedIn = false
+                        self.isLoading = false
+                    }
+                    return
+                }
                 self.currentUserEmail = firebaseUser.email
                 Task { await self.fetchUserData(uid: firebaseUser.uid) }
             } else {
@@ -69,6 +98,7 @@ class AuthViewModel: ObservableObject {
                     self.isGerente = false
                     self.currentUser = nil
                     self.currentUserEmail = nil
+                    self.pendingMicrosoftAutoLogin = false
                     // Don't touch requiresBiometricUnlock here — signOut() sets it directly
                 }
             }
@@ -203,6 +233,11 @@ class AuthViewModel: ObservableObject {
         await MainActor.run {
             isLoading = true
             errorMessage = nil
+            // The user is explicitly choosing Microsoft now — release the gate
+            // so the auth-state listener routes the resulting session into the
+            // app instead of bouncing back to "pending Microsoft auto login".
+            allowMicrosoftAutoEntry = true
+            pendingMicrosoftAutoLogin = false
         }
 
         do {
@@ -218,8 +253,29 @@ class AuthViewModel: ObservableObject {
             await MainActor.run {
                 self.errorMessage = "Microsoft Sign-In was cancelled or failed."
                 self.isLoading = false
+                // OAuth failed — re-arm the gate so a still-cached Firebase
+                // session won't sneak the user in on the next listener fire.
+                self.allowMicrosoftAutoEntry = false
             }
         }
+    }
+
+    /// Acknowledges a cached Microsoft session that was gated on app launch.
+    /// Reuses the existing Firebase credential — no OAuth re-prompt — and
+    /// runs the normal `fetchUserData` flow that sets `isLoggedIn = true`.
+    func continueWithCachedMicrosoftSession() async {
+        guard let firebaseUser = Auth.auth().currentUser else {
+            await MainActor.run { self.pendingMicrosoftAutoLogin = false }
+            return
+        }
+        await MainActor.run {
+            self.allowMicrosoftAutoEntry = true
+            self.pendingMicrosoftAutoLogin = false
+            self.isLoading = true
+            self.errorMessage = nil
+            self.currentUserEmail = firebaseUser.email
+        }
+        await fetchUserData(uid: firebaseUser.uid)
     }
     
     // MARK: - Biometric Sign In (from login screen)
@@ -378,6 +434,8 @@ class AuthViewModel: ObservableObject {
             currentUserEmail = nil
             requiresBiometricUnlock = false
             errorMessage = nil
+            pendingMicrosoftAutoLogin = false
+            allowMicrosoftAutoEntry = false
         }
     }
     // Stores the last role so biometric re-login can restore it in dev mode

--- a/sd-smart-parking/sd-smart-parking/Views/Login/LoginView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Login/LoginView.swift
@@ -25,6 +25,25 @@ struct LoginView: View {
         authVM.biometricType == .touchID ? "Continue with Touch ID" : "Continue with Face ID"
     }
 
+    /// Microsoft button switches into a "Continue as <email>" affordance when
+    /// a cached Firebase session is gated on launch (pendingMicrosoftAutoLogin).
+    /// The cached path needs a network connection to fetch Firestore data.
+    private var microsoftButtonLabel: String {
+        if authVM.pendingMicrosoftAutoLogin,
+           let email = authVM.currentUserEmail ?? lastMicrosoftEmail {
+            return "Continue as \(email)"
+        }
+        return "Continue with Microsoft"
+    }
+
+    private var microsoftButtonDisabled: Bool {
+        !networkMonitor.isConnected || authVM.isLoading
+    }
+
+    private var microsoftButtonOpacity: Double {
+        networkMonitor.isConnected ? 1.0 : 0.45
+    }
+
     var body: some View {
         NavigationStack {
             ScrollView {
@@ -133,21 +152,38 @@ struct LoginView: View {
                 .padding(.horizontal, 24)
 
                 // MARK: - Microsoft Button
-                if let lastEmail = lastMicrosoftEmail {
+                if authVM.pendingMicrosoftAutoLogin,
+                   let pendingEmail = authVM.currentUserEmail ?? lastMicrosoftEmail {
+                    // Cached Microsoft session present — explicit confirmation
+                    // required before we route into the app, so the user can
+                    // choose another method instead.
+                    Text("Microsoft session ready for \(pendingEmail). Tap to continue, or pick another method below.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .padding(.horizontal, 24)
+                } else if let lastEmail = lastMicrosoftEmail {
                     Text("Last Microsoft user: \(lastEmail)")
                         .font(.caption)
                         .foregroundColor(.secondary)
                         .padding(.horizontal, 24)
                 }
                 Button {
-                    Task { await authVM.signInWithMicrosoft() }
+                    Task {
+                        if authVM.pendingMicrosoftAutoLogin {
+                            // Reuse the cached Firebase credential — no OAuth
+                            // re-prompt, just acknowledgement of the session.
+                            await authVM.continueWithCachedMicrosoftSession()
+                        } else {
+                            await authVM.signInWithMicrosoft()
+                        }
+                    }
                 } label: {
                     HStack(spacing: 12) {
                         Image("Microsoft_Logo")
                             .resizable()
                             .scaledToFit()
                             .frame(width: 20, height: 20)
-                        Text("Continue with Microsoft")
+                        Text(microsoftButtonLabel)
                             .font(.body)
                             .fontWeight(.semibold)
                             .foregroundColor(.primary)
@@ -161,10 +197,10 @@ struct LoginView: View {
                             .stroke(Color.gray.opacity(0.2), lineWidth: 1)
                     )
                     .shadow(color: Color.black.opacity(0.05), radius: 3, x: 0, y: 2)
-                    .opacity(networkMonitor.isConnected ? 1.0 : 0.45)
+                    .opacity(microsoftButtonOpacity)
                 }
                 .contentShape(Rectangle())
-                .disabled(!networkMonitor.isConnected || authVM.isLoading)
+                .disabled(microsoftButtonDisabled)
                 .padding(.horizontal, 24)
 
                 if !networkMonitor.isConnected {

--- a/sd-smart-parking/sd-smart-parking/Views/Profile/EditProfileView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Profile/EditProfileView.swift
@@ -15,13 +15,22 @@ struct EditProfileView: View {
     @State private var name: String = ""
     @State private var email: String = ""
 
-    // Parking preferences (mirrors UserPreferences)
+    // Parking preferences (mirrors UserPreferences). Form-bound @State so the
+    // user can Cancel without persisting; we flush to UserDefaults + Firestore
+    // only on Save.
     @State private var hasMobilityLimitation: Bool = false
     @State private var preferredFloor: Int? = nil
 
     /// Local-only display toggle persisted via UserDefaults. `diego.` prefix
     /// keeps the namespace separate from teammate keys (e.g. biometricsEnabled).
     @AppStorage("diego.profile.showDemandBadgeOnDashboard") private var showDemandBadge: Bool = true
+
+    /// Parking preferences mirrored to UserDefaults so they survive a cold
+    /// start without depending on the Firestore round-trip (criterion 4 —
+    /// UserDefaults strategy). `-1` is the sentinel for "no preference"
+    /// because `@AppStorage` does not natively support `Int?`.
+    @AppStorage("diego.userPrefs.hasMobilityLimitation") private var storedHasMobility: Bool = false
+    @AppStorage("diego.userPrefs.preferredFloorRaw") private var storedPreferredFloorRaw: Int = -1
 
     var body: some View {
         NavigationStack {
@@ -49,8 +58,16 @@ struct EditProfileView: View {
                 if let user = userRepo.currentUser {
                     name = user.name
                     email = user.email
-                    hasMobilityLimitation = user.preferences?.hasMobilityLimitation ?? false
-                    preferredFloor = user.preferences?.preferredFloor
+                }
+                // Server-stored prefs win when present (multi-device sync);
+                // otherwise fall back to the UserDefaults snapshot so a
+                // cold-start offline still shows the user's last choice.
+                if let prefs = userRepo.currentUser?.preferences {
+                    hasMobilityLimitation = prefs.hasMobilityLimitation
+                    preferredFloor = prefs.preferredFloor
+                } else {
+                    hasMobilityLimitation = storedHasMobility
+                    preferredFloor = storedPreferredFloorRaw == -1 ? nil : storedPreferredFloorRaw
                 }
             }
             .toolbar {
@@ -67,6 +84,10 @@ struct EditProfileView: View {
                                 preferredFloor: preferredFloor
                             )
                         )
+                        // Mirror to UserDefaults so the choice survives a cold
+                        // start even if Firestore sync is queued offline.
+                        storedHasMobility = hasMobilityLimitation
+                        storedPreferredFloorRaw = preferredFloor ?? -1
                         dismiss()
                     }
                     .bold()


### PR DESCRIPTION
## Summary

- **Criterion 4 (Local Storage / UserDefaults).** `EditProfileView` now mirrors the parking preferences (`hasMobilityLimitation`, `preferredFloor`) to `@AppStorage("diego.userPrefs.*")` on Save. `.onAppear` prefers the server-stored value when present and falls back to the UserDefaults snapshot otherwise, so the choice survives a cold start without depending on the Firestore round-trip. Adds a load-bearing consumer for the UserDefaults strategy beyond the display-only `showDemandBadge` toggle.
- **UX fix — explicit Microsoft consent on launch.** `AuthViewModel` adds an in-memory gate (`allowMicrosoftAutoEntry`) so cached Microsoft sessions no longer auto-route the user into the app. The auth-state listener detects Microsoft via `providerData[].providerID == "microsoft.com"` and, when the gate is closed, surfaces `pendingMicrosoftAutoLogin = true`. `LoginView` swaps the Microsoft button into a "Continue as <email>" affordance so the user can confirm or pick another provider; the cached path reuses the Firebase credential without an OAuth re-prompt. `signInWithMicrosoft` and `continueWithCachedMicrosoftSession` release the gate; hard `signOut` and the listener nil branch reset it.

## Files touched

- `sd-smart-parking/ViewModels/AuthViewModel.swift` — gate + new `continueWithCachedMicrosoftSession` + state resets.
- `sd-smart-parking/Views/Login/LoginView.swift` — Microsoft button label/handler swap when `pendingMicrosoftAutoLogin == true`.
- `sd-smart-parking/Views/Profile/EditProfileView.swift` — `@AppStorage` mirror + Save flushes UserDefaults.

## Rubric impact

Criterion 4 (Local Storage) — UserDefaults strategy now drives a real preference (floor + mobility), strengthening the oral-defense narrative.

## Test plan

- [x] `XcodeBuildMCP build_sim` green on iPhone 17 (iOS 26.4).
- [x] `XcodeBuildMCP test_sim` green: 170/170 passing (existing `AuthViewModelMicrosoftTests` and `KeychainHelperTests` still pass).
- [ ] Manual UI:
  - [ ] EditProfile → toggle mobility + pick floor → Save → kill app → reopen EditProfile → values persist (UserDefaults survives cold start).
  - [ ] Sign in with Microsoft → kill app → reopen → LoginView shows "Continue as <email>" instead of auto-routing into the app. Tap → enters the app without OAuth re-prompt.
  - [ ] On the same screen, tap email/Google instead of Microsoft → Firebase swaps the session and routes in normally.
  - [ ] Hard logout → re-launch → no cached caption visible (gate reset).

## Notes

No teammate-authored files touched (Mateo / Juanes stack — `UserRepository`, `DiskPersistenceManager`, `NetworkMonitor`, etc. — untouched). UserDefaults keys keep the `diego.*` prefix to avoid colliding with `biometricsEnabled`. Microsoft gate uses `providerData` (Firebase API) rather than relying on the Keychain hint, so it's robust even if `MicrosoftKeychain` is empty.