### PR TITLE
feat(sprint4/diego): bulk plate lookup with concurrent Firestore search

### DIFF
--- a/sd-smart-parking/sd-smart-parking/ViewModels/BulkPlateLookupViewModel.swift
+++ b/sd-smart-parking/sd-smart-parking/ViewModels/BulkPlateLookupViewModel.swift
@@ -1,0 +1,164 @@
+//
+//  BulkPlateLookupViewModel.swift
+//  sd-smart-parking
+//
+//  Sprint 4 / Diego — multi-threading feature.
+//
+//  Drives BulkPlateLookupView: the Gerente pastes/types multiple plates and
+//  every plate is queried against Firestore CONCURRENTLY using
+//  `withTaskGroup`. Results stream into `resultsByPlate` as each child task
+//  completes so SwiftUI re-renders incrementally instead of waiting for the
+//  whole batch.
+//
+//  Why `withTaskGroup` instead of `async let`?
+//  Juanes' analytics already uses `async let` (fixed fan-out of 5 stats) and
+//  an `actor` (history serialization). `withTaskGroup` is the right pick
+//  here because fan-out is DYNAMIC — it equals however many plates the
+//  Gerente typed. Demonstrates a third concurrency primitive without
+//  duplicating teammate work.
+//
+//  Offline behavior lives here too: when the network is down we skip the
+//  TaskGroup and filter `ParkingViewModel.vehicleRecords` (already kept in
+//  memory by the existing Firestore listener) so the screen still shows the
+//  most recent local snapshot.
+//
+
+import Foundation
+import SwiftUI
+import Combine
+import FirebaseFirestore
+
+@MainActor
+final class BulkPlateLookupViewModel: ObservableObject {
+
+    // MARK: - State
+
+    @Published var rawInput: String = ""
+    @Published private(set) var resultsByPlate: [String: [VehicleRecord]] = [:]
+    @Published private(set) var inFlight: Set<String> = []
+    @Published private(set) var lastError: String?
+    @Published private(set) var lastRunAt: Date?
+    @Published private(set) var servedFromLocalSnapshot: Bool = false
+
+    private let db = Firestore.firestore()
+
+    // MARK: - Public API
+
+    /// Parses `rawInput`, normalises plates and runs them in parallel.
+    /// `localFallback` is the in-memory snapshot owned by `ParkingViewModel`,
+    /// used when the network is down.
+    func search(isOnline: Bool, localFallback: [VehicleRecord]) async {
+        let plates = parsePlates(rawInput)
+        guard !plates.isEmpty else {
+            lastError = "Enter at least one plate."
+            return
+        }
+
+        lastError = nil
+        resultsByPlate = [:]
+        inFlight = Set(plates)
+        servedFromLocalSnapshot = !isOnline
+
+        if !isOnline {
+            // Offline path: bucket the cached records by plate. O(n) over the
+            // already-loaded snapshot, no Firestore round-trip.
+            let bucketed = Dictionary(grouping: localFallback) { $0.plate.uppercased() }
+            for plate in plates {
+                resultsByPlate[plate] = bucketed[plate] ?? []
+                inFlight.remove(plate)
+            }
+            lastRunAt = Date()
+            return
+        }
+
+        // Online path: one child task per plate, all running concurrently.
+        await withTaskGroup(of: (String, [VehicleRecord]).self) { group in
+            for plate in plates {
+                group.addTask { [db] in
+                    let records = await Self.fetchRecords(for: plate, db: db)
+                    return (plate, records)
+                }
+            }
+
+            for await (plate, records) in group {
+                self.resultsByPlate[plate] = records
+                self.inFlight.remove(plate)
+            }
+        }
+
+        lastRunAt = Date()
+    }
+
+    func clear() {
+        rawInput = ""
+        resultsByPlate = [:]
+        inFlight = []
+        lastError = nil
+        lastRunAt = nil
+        servedFromLocalSnapshot = false
+    }
+
+    // MARK: - Plate parsing
+
+    /// Splits on newlines, commas, or whitespace; upper-cases; drops empties;
+    /// dedupes preserving input order.
+    func parsePlates(_ raw: String) -> [String] {
+        let separators = CharacterSet.whitespacesAndNewlines.union(CharacterSet(charactersIn: ",;"))
+        var seen = Set<String>()
+        var ordered: [String] = []
+        for piece in raw.components(separatedBy: separators) {
+            let cleaned = piece.uppercased().trimmingCharacters(in: .whitespaces)
+            guard !cleaned.isEmpty, !seen.contains(cleaned) else { continue }
+            seen.insert(cleaned)
+            ordered.append(cleaned)
+        }
+        return ordered
+    }
+
+    // MARK: - Firestore
+
+    /// Pulls every vehicleRecord matching `plate` and decodes it the same way
+    /// `ParkingViewModel.listenToRecords()` does. Static + nonisolated so it
+    /// can be safely invoked from any TaskGroup child without crossing actor
+    /// boundaries.
+    nonisolated private static func fetchRecords(
+        for plate: String,
+        db: Firestore
+    ) async -> [VehicleRecord] {
+        do {
+            let snapshot = try await db.collection("vehicleRecords")
+                .whereField("plate", isEqualTo: plate)
+                .order(by: "timestamp", descending: true)
+                .limit(to: 25)
+                .getDocuments()
+
+            return snapshot.documents.compactMap { Self.decode(doc: $0) }
+        } catch {
+            return []
+        }
+    }
+
+    nonisolated private static func decode(doc: QueryDocumentSnapshot) -> VehicleRecord? {
+        let data = doc.data()
+        guard let plate     = data["plate"]     as? String,
+              let typeRaw   = data["type"]      as? String,
+              let type      = RecordType(rawValue: typeRaw),
+              let timestamp = (data["timestamp"] as? Timestamp)?.dateValue()
+        else { return nil }
+
+        return VehicleRecord(
+            id: doc.documentID,
+            plate: plate,
+            type: type,
+            timestamp: timestamp,
+            floor: data["floor"] as? Int,
+            spotNumber: data["spotNumber"] as? Int,
+            photoURL: data["photoURL"] as? String,
+            isRegistered: data["isRegistered"] as? Bool ?? false,
+            ownerEmail: data["ownerEmail"] as? String,
+            ocrConfidence: data["ocrConfidence"] as? Double ?? 1.0,
+            durationHours: data["durationHours"] as? Double,
+            hitDailyCap: data["hitDailyCap"] as? Bool ?? false
+        )
+    }
+}

--- a/sd-smart-parking/sd-smart-parking/Views/Gerente/BulkPlateLookupView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Gerente/BulkPlateLookupView.swift
@@ -1,0 +1,218 @@
+//
+//  BulkPlateLookupView.swift
+//  sd-smart-parking
+//
+//  Sprint 4 / Diego — multi-threading feature.
+//
+//  Gerente pastes/types several plates (newline, comma or whitespace
+//  separated). Tapping "Search all" fans out one concurrent Firestore query
+//  per plate via `BulkPlateLookupViewModel.search` (which uses
+//  `withTaskGroup`). Result cards stream in incrementally as each child
+//  task finishes.
+//
+
+import SwiftUI
+
+struct BulkPlateLookupView: View {
+    @EnvironmentObject private var parkingVM: ParkingViewModel
+    @EnvironmentObject private var network: NetworkMonitor
+    @StateObject private var vm = BulkPlateLookupViewModel()
+    @FocusState private var inputFocused: Bool
+
+    var body: some View {
+        NavigationStack {
+            VStack(alignment: .leading, spacing: 12) {
+                if !network.isConnected {
+                    OfflineNoticeBadge(
+                        message: "Offline — searching the in-memory snapshot"
+                    )
+                    .padding(.horizontal)
+                }
+
+                inputCard
+
+                if let err = vm.lastError {
+                    Text(err)
+                        .font(.footnote)
+                        .foregroundStyle(.red)
+                        .padding(.horizontal)
+                }
+
+                if vm.servedFromLocalSnapshot && !vm.resultsByPlate.isEmpty {
+                    Text("Showing cached snapshot (offline)")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal)
+                }
+
+                resultsList
+            }
+            .padding(.top, 12)
+            .background(Color(.systemGroupedBackground))
+            .navigationTitle("Bulk Plate Lookup")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Clear") { vm.clear() }
+                        .disabled(vm.rawInput.isEmpty && vm.resultsByPlate.isEmpty)
+                }
+            }
+        }
+    }
+
+    // MARK: - Sub-views
+
+    private var inputCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Plates")
+                .font(.subheadline.weight(.semibold))
+            TextEditor(text: $vm.rawInput)
+                .focused($inputFocused)
+                .textInputAutocapitalization(.characters)
+                .autocorrectionDisabled(true)
+                .frame(minHeight: 90, maxHeight: 140)
+                .padding(8)
+                .background(Color(.secondarySystemBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+
+            Text("Separate by line, comma, or space. e.g. ABC123 DEF456")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+
+            HStack {
+                Spacer()
+                Button {
+                    inputFocused = false
+                    Task {
+                        await vm.search(
+                            isOnline: network.isConnected,
+                            localFallback: parkingVM.vehicleRecords
+                        )
+                    }
+                } label: {
+                    Label("Search all", systemImage: "magnifyingglass.circle.fill")
+                        .font(.subheadline.weight(.semibold))
+                        .padding(.horizontal, 18)
+                        .padding(.vertical, 10)
+                        .background(Color.blue)
+                        .foregroundStyle(.white)
+                        .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+                .disabled(vm.rawInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+        .padding(14)
+        .background(Color.white)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 2)
+        .padding(.horizontal)
+    }
+
+    private var resultsList: some View {
+        ScrollView {
+            VStack(spacing: 12) {
+                ForEach(orderedPlates, id: \.self) { plate in
+                    PlateResultCard(
+                        plate: plate,
+                        records: vm.resultsByPlate[plate] ?? [],
+                        isLoading: vm.inFlight.contains(plate)
+                    )
+                }
+
+                if vm.resultsByPlate.isEmpty && vm.inFlight.isEmpty {
+                    emptyState
+                }
+            }
+            .padding(.horizontal)
+            .padding(.bottom, 24)
+        }
+    }
+
+    private var orderedPlates: [String] {
+        // Keep the plates in the order the Gerente typed them so the cards
+        // don't jump around as TaskGroup children resolve out of order.
+        let typed = vm.parsePlates(vm.rawInput)
+        let extras = vm.resultsByPlate.keys.filter { !typed.contains($0) }
+        return typed + extras.sorted()
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 32))
+                .foregroundStyle(.secondary)
+            Text("Enter plates above and tap Search all")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 40)
+    }
+}
+
+// MARK: - Result card
+
+private struct PlateResultCard: View {
+    let plate: String
+    let records: [VehicleRecord]
+    let isLoading: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Text(plate)
+                    .font(.headline)
+                Spacer()
+                if isLoading {
+                    ProgressView().scaleEffect(0.75)
+                } else {
+                    Text("\(records.count) record\(records.count == 1 ? "" : "s")")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            if !isLoading {
+                if records.isEmpty {
+                    Text("No records for this plate.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(records.prefix(5)) { rec in
+                        HStack(spacing: 6) {
+                            Image(systemName: rec.type.icon)
+                                .foregroundStyle(rec.type.color)
+                                .font(.caption)
+                            Text(rec.type.label).font(.caption)
+                            Spacer()
+                            if let floor = rec.floor {
+                                Text("Floor \(floor)")
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Text(rec.timestamp.formatted(date: .abbreviated, time: .shortened))
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    if records.count > 5 {
+                        Text("+ \(records.count - 5) more")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+        .padding(12)
+        .background(Color.white)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 2)
+    }
+}
+
+#Preview {
+    BulkPlateLookupView()
+        .environmentObject(ParkingViewModel())
+        .environmentObject(NetworkMonitor.shared)
+}

--- a/sd-smart-parking/sd-smart-parking/Views/Gerente/RegistroVehiculosView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Gerente/RegistroVehiculosView.swift
@@ -14,6 +14,7 @@ struct RegistroVehiculosView: View {
     @State private var selectedFilter: RecordFilter = .all
     @State private var selectedRecord: VehicleRecord? = nil
     @State private var showingCreateRecord: Bool = false
+    @State private var showingBulkLookup: Bool = false
     
     
     
@@ -98,9 +99,19 @@ struct RegistroVehiculosView: View {
             .navigationTitle("Vehicle Registry")
             .searchable(text: $searchText, prompt: "Search plate")
             .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button {
+                        showingBulkLookup = true
+                    } label: {
+                        Image(systemName: "magnifyingglass.circle")
+                            .foregroundStyle(.blue)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Bulk plate lookup")
+                }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button {
-                        
+
                         showingCreateRecord = true
                     } label: {
                         Image(systemName: "plus")
@@ -116,6 +127,11 @@ struct RegistroVehiculosView: View {
             }
             .sheet(item: $selectedRecord) { record in
                 RecordDetailView(record: record).environmentObject(vm)
+            }
+            .sheet(isPresented: $showingBulkLookup) {
+                BulkPlateLookupView()
+                    .environmentObject(vm)
+                    .environmentObject(NetworkMonitor.shared)
             }
         }
     }


### PR DESCRIPTION
## What does this PR do?
Adds a new Gerente tool — **Bulk Plate Lookup** — that runs several plate searches against `vehicleRecords` **concurrently** via `withTaskGroup` and streams the result cards into the UI as each child task resolves.

## Why is this change needed?
Sprint 4 rubric point **(a)** requires at least one new feature with an explicit multi-threading / concurrency strategy. Juanes' analytics already cover `async let` (fixed fan-out) and `actor` (history serialization). This feature covers the third common Swift concurrency primitive — `withTaskGroup` for *dynamic* fan-out driven by user input — without overlapping his work.

## How was it implemented?
- `BulkPlateLookupViewModel` (`@MainActor` `ObservableObject`):
  - Parses the raw input into a deduped, upper-cased plate list.
  - `withTaskGroup(of: (String, [VehicleRecord]).self)` — one child task per plate, each issuing a `whereField("plate", isEqualTo:)` query against `vehicleRecords`.
  - Streams `(plate, records)` into `@Published var resultsByPlate` as each task finishes → SwiftUI re-renders incrementally instead of waiting for the whole batch.
  - Firestore decoding mirrors the existing logic in `ParkingViewModel.listenToRecords()`.
- `BulkPlateLookupView`:
  - Multi-line `TextEditor` for plate input, "Search all" button.
  - Result cards with per-card `ProgressView` spinner while in-flight.
- Wired from `RegistroVehiculosView` via a new leading toolbar button (`magnifyingglass.circle`) that presents the view as a sheet.

## Eventual connectivity
Reuses `NetworkMonitor.shared`. Offline path skips the TaskGroup and buckets the in-memory `ParkingViewModel.vehicleRecords` (already kept warm by the existing Firestore listener) so the screen still works. `OfflineNoticeBadge` is rendered at the top.

## Related Issue
Closes #86

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Xcode 26.3, iPhone 17 simulator, iOS 26.0.
- `build_sim` via XcodeBuildMCP — succeeds, no new warnings.
- Manual smoke: opened the new sheet from Vehicles tab, pasted 5 plates including one unknown — cards streamed in, unknown card showed empty state.

## Checklist
- [x] Self-review of own code
- [x] Follows existing MVVM + `ObservableObject` + `@Published` pattern
- [x] Reuses existing infrastructure (`NetworkMonitor`, `OfflineNoticeBadge`)
- [x] No edits to `project.pbxproj`, `Info.plist`, or teammate code beyond the additive toolbar button
- [x] No new third-party dependencies