### PR TITLE
feat(sprint4/diego): pinned plates with disk-backed bookmarks

### DIFF
--- a/sd-smart-parking/sd-smart-parking/Models/PinnedPlate.swift
+++ b/sd-smart-parking/sd-smart-parking/Models/PinnedPlate.swift
@@ -1,0 +1,20 @@
+//
+//  PinnedPlate.swift
+//  sd-smart-parking
+//
+//  Sprint 4 / Diego — local-storage feature.
+//
+//  Minimal Codable value the Gerente keeps locally to bookmark plates they
+//  look up often. Persisted via KeyValueStore (Documents/diego.kv/...) so it
+//  survives app restarts and is available offline.
+//
+
+import Foundation
+
+struct PinnedPlate: Identifiable, Codable, Hashable {
+    let plate: String
+    let pinnedAt: Date
+    var note: String?
+
+    var id: String { plate }
+}

--- a/sd-smart-parking/sd-smart-parking/ViewModels/PinnedPlatesViewModel.swift
+++ b/sd-smart-parking/sd-smart-parking/ViewModels/PinnedPlatesViewModel.swift
@@ -1,0 +1,81 @@
+//
+//  PinnedPlatesViewModel.swift
+//  sd-smart-parking
+//
+//  Sprint 4 / Diego — local-storage feature.
+//
+//  Drives PinnedPlatesView. Persists Gerente-pinned plates on disk via
+//  KeyValueStore<String, PinnedPlate> scoped to "diego.pinned-plates"
+//  (Documents/diego.kv/diego.pinned-plates.json).
+//
+//  Storage choice:
+//    KeyValueStore writes a JSON blob keyed by plate, so every operation
+//    (pin/unpin/exists) is O(1) on the in-memory dictionary, with a
+//    barrier-write JSON encode happening on the store's concurrent queue.
+//    Picked over SwiftData / CoreData because the dataset is tiny and the
+//    existing K/V store is already approved infrastructure in this repo.
+//
+//  Works fully offline by definition — there is no network round-trip.
+//
+
+import Foundation
+import SwiftUI
+import Combine
+
+@MainActor
+final class PinnedPlatesViewModel: ObservableObject {
+
+    @Published private(set) var pinned: [PinnedPlate] = []
+
+    private let store: KeyValueStore<String, PinnedPlate>
+
+    init(scope: String = "diego.pinned-plates") {
+        self.store = KeyValueStore<String, PinnedPlate>(scope: scope)
+        reload()
+    }
+
+    // MARK: - Public API
+
+    func isPinned(_ plate: String) -> Bool {
+        store[normalize(plate)] != nil
+    }
+
+    func pin(_ plate: String, note: String? = nil) {
+        let key = normalize(plate)
+        guard !key.isEmpty else { return }
+        let entry = PinnedPlate(plate: key, pinnedAt: Date(), note: note)
+        store.put(entry, forKey: key)
+        reload()
+    }
+
+    func unpin(_ plate: String) {
+        store.remove(normalize(plate))
+        reload()
+    }
+
+    func toggle(_ plate: String) {
+        let key = normalize(plate)
+        if isPinned(key) { unpin(key) } else { pin(key) }
+    }
+
+    func updateNote(_ plate: String, note: String?) {
+        let key = normalize(plate)
+        guard var current = store[key] else { return }
+        current.note = note?.isEmpty == true ? nil : note
+        store.put(current, forKey: key)
+        reload()
+    }
+
+    // MARK: - Internals
+
+    /// Read the on-disk snapshot and sort most-recent-pin-first.
+    func reload() {
+        pinned = store.snapshot()
+            .values
+            .sorted { $0.pinnedAt > $1.pinnedAt }
+    }
+
+    private func normalize(_ plate: String) -> String {
+        plate.uppercased().trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/sd-smart-parking/sd-smart-parking/Views/Gerente/PinnedPlatesView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Gerente/PinnedPlatesView.swift
@@ -1,0 +1,163 @@
+//
+//  PinnedPlatesView.swift
+//  sd-smart-parking
+//
+//  Sprint 4 / Diego — local-storage feature.
+//
+//  Lists the plates the Gerente has bookmarked. Reads from
+//  PinnedPlatesViewModel which is backed by KeyValueStore on disk. Tapping
+//  a row jumps into the matching record via the existing RecordDetailView;
+//  if no record exists yet the row shows "no records" and acts purely as
+//  the pinned bookmark.
+//
+
+import SwiftUI
+
+struct PinnedPlatesView: View {
+    @EnvironmentObject private var parkingVM: ParkingViewModel
+    @StateObject private var vm = PinnedPlatesViewModel()
+    @State private var selectedRecord: VehicleRecord? = nil
+    @State private var noteDraftFor: PinnedPlate? = nil
+    @State private var noteDraftText: String = ""
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if vm.pinned.isEmpty {
+                    emptyState
+                } else {
+                    List {
+                        ForEach(vm.pinned) { entry in
+                            row(entry)
+                                .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                                    Button(role: .destructive) {
+                                        vm.unpin(entry.plate)
+                                    } label: {
+                                        Label("Unpin", systemImage: "star.slash")
+                                    }
+                                }
+                                .swipeActions(edge: .leading) {
+                                    Button {
+                                        noteDraftFor = entry
+                                        noteDraftText = entry.note ?? ""
+                                    } label: {
+                                        Label("Note", systemImage: "square.and.pencil")
+                                    }
+                                    .tint(.blue)
+                                }
+                        }
+                    }
+                    .listStyle(.insetGrouped)
+                }
+            }
+            .background(Color(.systemGroupedBackground))
+            .navigationTitle("Pinned Plates")
+            .navigationBarTitleDisplayMode(.inline)
+            .sheet(item: $selectedRecord) { record in
+                RecordDetailView(record: record)
+                    .environmentObject(parkingVM)
+            }
+            .sheet(item: $noteDraftFor) { entry in
+                noteEditor(for: entry)
+            }
+        }
+    }
+
+    // MARK: - Row
+
+    private func row(_ entry: PinnedPlate) -> some View {
+        Button {
+            if let rec = mostRecentRecord(for: entry.plate) {
+                selectedRecord = rec
+            }
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: "star.fill")
+                    .foregroundStyle(.yellow)
+                    .font(.title3)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(entry.plate)
+                        .font(.headline)
+                    if let note = entry.note, !note.isEmpty {
+                        Text(note)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                    }
+                    Text("Pinned \(entry.pinnedAt.formatted(date: .abbreviated, time: .omitted))")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+                Spacer()
+                if let rec = mostRecentRecord(for: entry.plate) {
+                    VStack(alignment: .trailing) {
+                        Image(systemName: rec.type.icon)
+                            .foregroundStyle(rec.type.color)
+                        Text(rec.timestamp.formatted(date: .abbreviated, time: .omitted))
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    Text("No records")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func mostRecentRecord(for plate: String) -> VehicleRecord? {
+        parkingVM.vehicleRecords
+            .filter { $0.plate.uppercased() == plate }
+            .sorted { $0.timestamp > $1.timestamp }
+            .first
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "star")
+                .font(.system(size: 38))
+                .foregroundStyle(.secondary)
+            Text("No pinned plates yet")
+                .font(.headline)
+            Text("Pin a plate from the vehicle registry to keep it one tap away here.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Note editor
+
+    private func noteEditor(for entry: PinnedPlate) -> some View {
+        NavigationStack {
+            Form {
+                Section("Note for \(entry.plate)") {
+                    TextField("Optional note", text: $noteDraftText, axis: .vertical)
+                        .lineLimit(3...6)
+                }
+            }
+            .navigationTitle("Edit note")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { noteDraftFor = nil }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        vm.updateNote(entry.plate, note: noteDraftText)
+                        noteDraftFor = nil
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    PinnedPlatesView()
+        .environmentObject(ParkingViewModel())
+}

--- a/sd-smart-parking/sd-smart-parking/Views/Gerente/RegistroVehiculosView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Gerente/RegistroVehiculosView.swift
@@ -15,6 +15,8 @@ struct RegistroVehiculosView: View {
     @State private var selectedRecord: VehicleRecord? = nil
     @State private var showingCreateRecord: Bool = false
     @State private var showingBulkLookup: Bool = false
+    @State private var showingPinned: Bool = false
+    @StateObject private var pinnedVM = PinnedPlatesViewModel()
     
     
     
@@ -88,6 +90,18 @@ struct RegistroVehiculosView: View {
                                     Label("Delete", systemImage: "trash")
                                 }
                             }
+                            .swipeActions(edge: .leading, allowsFullSwipe: true) {
+                                Button {
+                                    pinnedVM.toggle(record.plate)
+                                } label: {
+                                    if pinnedVM.isPinned(record.plate) {
+                                        Label("Unpin", systemImage: "star.slash")
+                                    } else {
+                                        Label("Pin", systemImage: "star.fill")
+                                    }
+                                }
+                                .tint(.yellow)
+                            }
                         }
                     }
                     .listStyle(.plain)
@@ -108,6 +122,16 @@ struct RegistroVehiculosView: View {
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel("Bulk plate lookup")
+                }
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button {
+                        showingPinned = true
+                    } label: {
+                        Image(systemName: pinnedVM.pinned.isEmpty ? "star" : "star.fill")
+                            .foregroundStyle(.yellow)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Pinned plates")
                 }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button {
@@ -132,6 +156,10 @@ struct RegistroVehiculosView: View {
                 BulkPlateLookupView()
                     .environmentObject(vm)
                     .environmentObject(NetworkMonitor.shared)
+            }
+            .sheet(isPresented: $showingPinned, onDismiss: { pinnedVM.reload() }) {
+                PinnedPlatesView()
+                    .environmentObject(vm)
             }
         }
     }


### PR DESCRIPTION
## What does this PR do?
Adds **Pinned Plates** — the Gerente can star plates from the vehicle registry and reach them with one tap from a dedicated screen. Pinned entries persist on disk, support optional notes, and work fully offline.

## Why is this change needed?
Sprint 4 rubric point **(b)** requires at least one new feature with an explicit local-storage strategy. This feature persists `PinnedPlate` values via `KeyValueStore<String, PinnedPlate>` (the team's existing thread-safe JSON store under `Documents/diego.kv/`). No new third-party dependency, no SwiftData/CoreData migration — leverages infrastructure already approved in the repo.

## How was it implemented?
- `PinnedPlate` (Codable, Hashable, Identifiable) — plate, pinnedAt, optional note.
- `PinnedPlatesViewModel` (`@MainActor` `ObservableObject`) — owns a `KeyValueStore` instance scoped to `diego.pinned-plates`. `pin/unpin/toggle/isPinned/updateNote` are O(1) on the in-memory dictionary; the store flushes to disk via the concurrent queue's barrier write.
- `PinnedPlatesView` — list with empty state, leading swipe to edit note, trailing destructive swipe to unpin, tap row to jump into the existing `RecordDetailView` when a record exists for that plate.
- `RegistroVehiculosView`:
  - Second leading toolbar item (`star` / `star.fill`) presents `PinnedPlatesView` as a sheet; the icon reflects whether any plate is currently pinned.
  - Leading swipe on a record row toggles pin instantly.

## Eventual connectivity
Purely local feature — no network round-trip, no Firestore call. Pinning, listing, and notes all work offline.

## Related Issue
Closes #88

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Xcode 26.3, iPhone 17 simulator, iOS 26.0.
- `build_sim` via XcodeBuildMCP — succeeds, no new warnings introduced.
- Smoke: pinned a plate from registry swipe → opened pinned sheet → added a note → force-quit + relaunch → entries still there.

## Checklist
- [x] Self-review of own code
- [x] Follows existing MVVM + `ObservableObject` + `@Published` pattern
- [x] Reuses existing infrastructure (`KeyValueStore`, `RecordDetailView`)
- [x] No edits to `project.pbxproj`, `Info.plist`, or teammate code beyond additive toolbar buttons + leading swipe
- [x] No new third-party dependencies