### PR TITLE
feat(sprint4/diego): two-layer cache for bulk plate lookup

### DIFF
--- a/sd-smart-parking/sd-smart-parking/Models/CachedLookup.swift
+++ b/sd-smart-parking/sd-smart-parking/Models/CachedLookup.swift
@@ -1,0 +1,19 @@
+//
+//  CachedLookup.swift
+//  sd-smart-parking
+//
+//  Sprint 4 / Diego — caching feature.
+//
+//  Disk-persisted snapshot of a single plate's last bulk-lookup result.
+//  Lives inside KeyValueStore<String, CachedLookup> scoped to
+//  "diego.recent-lookups" so the BulkPlateLookupView can serve previously
+//  fetched results instantly on a repeat search (and stay useful offline).
+//
+
+import Foundation
+
+struct CachedLookup: Codable, Hashable {
+    let plate: String
+    let records: [VehicleRecord]
+    let cachedAt: Date
+}

--- a/sd-smart-parking/sd-smart-parking/ViewModels/BulkPlateLookupViewModel.swift
+++ b/sd-smart-parking/sd-smart-parking/ViewModels/BulkPlateLookupViewModel.swift
@@ -2,25 +2,27 @@
 //  BulkPlateLookupViewModel.swift
 //  sd-smart-parking
 //
-//  Sprint 4 / Diego — multi-threading feature.
+//  Sprint 4 / Diego — multi-threading feature + caching feature.
 //
-//  Drives BulkPlateLookupView: the Gerente pastes/types multiple plates and
-//  every plate is queried against Firestore CONCURRENTLY using
-//  `withTaskGroup`. Results stream into `resultsByPlate` as each child task
-//  completes so SwiftUI re-renders incrementally instead of waiting for the
-//  whole batch.
+//  Drives BulkPlateLookupView. Two responsibilities:
 //
-//  Why `withTaskGroup` instead of `async let`?
-//  Juanes' analytics already uses `async let` (fixed fan-out of 5 stats) and
-//  an `actor` (history serialization). `withTaskGroup` is the right pick
-//  here because fan-out is DYNAMIC — it equals however many plates the
-//  Gerente typed. Demonstrates a third concurrency primitive without
-//  duplicating teammate work.
+//   1) Concurrency (rubric a): every plate the Gerente enters is queried in
+//      parallel via `withTaskGroup`. Fan-out is DYNAMIC (driven by user
+//      input), which is what justifies using a task group instead of the
+//      fixed `async let` and `actor` patterns already shipped by Juanes.
 //
-//  Offline behavior lives here too: when the network is down we skip the
-//  TaskGroup and filter `ParkingViewModel.vehicleRecords` (already kept in
-//  memory by the existing Firestore listener) so the screen still shows the
-//  most recent local snapshot.
+//   2) Caching (rubric c): per-plate results live in a two-layer cache:
+//        • Memory: NSCache<NSString, CachedLookupBox>, evicts under
+//          pressure, instant within-session re-reads.
+//        • Disk: KeyValueStore<String, CachedLookup> at
+//          Documents/diego.kv/diego.recent-lookups.json, survives restarts
+//          and serves as the offline fallback.
+//      Read order is memory → disk → Firestore. Writes go to both layers.
+//
+//  Offline behaviour: skips the TaskGroup, serves whatever the cache (memory
+//  + disk) has. If the cache misses too we additionally bucket
+//  `ParkingViewModel.vehicleRecords` (the live Firestore snapshot kept in
+//  memory by `listenToRecords`) as a final fallback.
 //
 
 import Foundation
@@ -31,6 +33,12 @@ import FirebaseFirestore
 @MainActor
 final class BulkPlateLookupViewModel: ObservableObject {
 
+    // MARK: - Tunables
+
+    private static let recentTermsLimit = 10
+    private static let diskCacheMaxEntries = 50
+    private static let recentTermsKey = "diego.recent-lookup-terms"
+
     // MARK: - State
 
     @Published var rawInput: String = ""
@@ -39,14 +47,36 @@ final class BulkPlateLookupViewModel: ObservableObject {
     @Published private(set) var lastError: String?
     @Published private(set) var lastRunAt: Date?
     @Published private(set) var servedFromLocalSnapshot: Bool = false
+    /// Plates whose currently-shown result came from the disk/memory cache.
+    /// Cleared once Firestore returns a fresh result for that plate.
+    @Published private(set) var cachedPlates: Set<String> = []
+    /// Most-recent search inputs, newest first, deduped.
+    @Published private(set) var recentTerms: [String] = []
 
+    // MARK: - Caches
+
+    private let memoryCache = NSCache<NSString, CachedLookupBox>()
+    private let diskCache: KeyValueStore<String, CachedLookup>
     private let db = Firestore.firestore()
+    private let defaults: UserDefaults
+
+    // MARK: - Init
+
+    init(
+        diskScope: String = "diego.recent-lookups",
+        defaults: UserDefaults = .standard
+    ) {
+        self.diskCache = KeyValueStore<String, CachedLookup>(scope: diskScope)
+        self.defaults = defaults
+        memoryCache.countLimit = 50
+        loadRecentTerms()
+    }
 
     // MARK: - Public API
 
     /// Parses `rawInput`, normalises plates and runs them in parallel.
     /// `localFallback` is the in-memory snapshot owned by `ParkingViewModel`,
-    /// used when the network is down.
+    /// used when the network is down and the cache misses.
     func search(isOnline: Bool, localFallback: [VehicleRecord]) async {
         let plates = parsePlates(rawInput)
         guard !plates.isEmpty else {
@@ -55,38 +85,20 @@ final class BulkPlateLookupViewModel: ObservableObject {
         }
 
         lastError = nil
-        resultsByPlate = [:]
-        inFlight = Set(plates)
-        servedFromLocalSnapshot = !isOnline
+        rememberRecentTerm(rawInput)
 
-        if !isOnline {
-            // Offline path: bucket the cached records by plate. O(n) over the
-            // already-loaded snapshot, no Firestore round-trip.
-            let bucketed = Dictionary(grouping: localFallback) { $0.plate.uppercased() }
-            for plate in plates {
-                resultsByPlate[plate] = bucketed[plate] ?? []
-                inFlight.remove(plate)
-            }
-            lastRunAt = Date()
-            return
-        }
+        await run(plates: plates, isOnline: isOnline, localFallback: localFallback)
+    }
 
-        // Online path: one child task per plate, all running concurrently.
-        await withTaskGroup(of: (String, [VehicleRecord]).self) { group in
-            for plate in plates {
-                group.addTask { [db] in
-                    let records = await Self.fetchRecords(for: plate, db: db)
-                    return (plate, records)
-                }
-            }
-
-            for await (plate, records) in group {
-                self.resultsByPlate[plate] = records
-                self.inFlight.remove(plate)
-            }
-        }
-
-        lastRunAt = Date()
+    /// Rerun a previous search term without retyping it (called from the
+    /// Recent searches list in the view).
+    func rerun(
+        term: String,
+        isOnline: Bool,
+        localFallback: [VehicleRecord]
+    ) async {
+        rawInput = term
+        await search(isOnline: isOnline, localFallback: localFallback)
     }
 
     func clear() {
@@ -96,14 +108,18 @@ final class BulkPlateLookupViewModel: ObservableObject {
         lastError = nil
         lastRunAt = nil
         servedFromLocalSnapshot = false
+        cachedPlates = []
     }
 
-    // MARK: - Plate parsing
+    func clearRecentTerms() {
+        recentTerms = []
+        defaults.removeObject(forKey: Self.recentTermsKey)
+    }
 
-    /// Splits on newlines, commas, or whitespace; upper-cases; drops empties;
-    /// dedupes preserving input order.
+    /// Plate parsing exposed so the view can show cards in input order.
     func parsePlates(_ raw: String) -> [String] {
-        let separators = CharacterSet.whitespacesAndNewlines.union(CharacterSet(charactersIn: ",;"))
+        let separators = CharacterSet.whitespacesAndNewlines
+            .union(CharacterSet(charactersIn: ",;"))
         var seen = Set<String>()
         var ordered: [String] = []
         for piece in raw.components(separatedBy: separators) {
@@ -115,12 +131,120 @@ final class BulkPlateLookupViewModel: ObservableObject {
         return ordered
     }
 
+    // MARK: - Core search
+
+    private func run(
+        plates: [String],
+        isOnline: Bool,
+        localFallback: [VehicleRecord]
+    ) async {
+        resultsByPlate = [:]
+        cachedPlates = []
+        inFlight = Set(plates)
+        servedFromLocalSnapshot = !isOnline
+
+        // Step 1: serve everything we already have cached so the UI fills
+        // immediately. This is what makes a repeat search feel instant.
+        for plate in plates {
+            if let hit = cacheLookup(plate: plate) {
+                resultsByPlate[plate] = hit.records
+                cachedPlates.insert(plate)
+                if !isOnline {
+                    inFlight.remove(plate)
+                }
+            }
+        }
+
+        // Step 2: choose the source of truth for the next refresh.
+        if !isOnline {
+            // Offline: fill any cache misses from the in-memory Firestore
+            // snapshot bucketed by plate.
+            let bucketed = Dictionary(grouping: localFallback) { $0.plate.uppercased() }
+            for plate in plates where resultsByPlate[plate] == nil {
+                resultsByPlate[plate] = bucketed[plate] ?? []
+                inFlight.remove(plate)
+            }
+            lastRunAt = Date()
+            return
+        }
+
+        // Online: refresh every plate concurrently via TaskGroup so cached
+        // entries get replaced with fresh data.
+        await withTaskGroup(of: (String, [VehicleRecord]).self) { group in
+            for plate in plates {
+                group.addTask { [db] in
+                    let records = await Self.fetchRecords(for: plate, db: db)
+                    return (plate, records)
+                }
+            }
+
+            for await (plate, records) in group {
+                resultsByPlate[plate] = records
+                cachedPlates.remove(plate)
+                inFlight.remove(plate)
+                writeCache(plate: plate, records: records)
+            }
+        }
+
+        lastRunAt = Date()
+    }
+
+    // MARK: - Cache layer
+
+    private func cacheLookup(plate: String) -> CachedLookup? {
+        if let box = memoryCache.object(forKey: plate as NSString) {
+            return box.value
+        }
+        if let onDisk = diskCache[plate] {
+            // Backfill the memory layer so the next read in this session
+            // doesn't touch disk.
+            memoryCache.setObject(CachedLookupBox(onDisk), forKey: plate as NSString)
+            return onDisk
+        }
+        return nil
+    }
+
+    private func writeCache(plate: String, records: [VehicleRecord]) {
+        let entry = CachedLookup(plate: plate, records: records, cachedAt: Date())
+        memoryCache.setObject(CachedLookupBox(entry), forKey: plate as NSString)
+        diskCache.put(entry, forKey: plate)
+        trimDiskCacheIfNeeded()
+    }
+
+    /// Keep the disk cache bounded by evicting the oldest entries. Cheap
+    /// because the snapshot is tiny — we only walk it after a write.
+    private func trimDiskCacheIfNeeded() {
+        let snap = diskCache.snapshot()
+        guard snap.count > Self.diskCacheMaxEntries else { return }
+        let oldest = snap.values
+            .sorted { $0.cachedAt < $1.cachedAt }
+            .prefix(snap.count - Self.diskCacheMaxEntries)
+        for entry in oldest {
+            diskCache.remove(entry.plate)
+            memoryCache.removeObject(forKey: entry.plate as NSString)
+        }
+    }
+
+    // MARK: - Recent terms
+
+    private func loadRecentTerms() {
+        recentTerms = defaults.stringArray(forKey: Self.recentTermsKey) ?? []
+    }
+
+    private func rememberRecentTerm(_ raw: String) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        var next = recentTerms.filter { $0 != trimmed }
+        next.insert(trimmed, at: 0)
+        if next.count > Self.recentTermsLimit {
+            next = Array(next.prefix(Self.recentTermsLimit))
+        }
+        recentTerms = next
+        defaults.set(next, forKey: Self.recentTermsKey)
+    }
+
     // MARK: - Firestore
 
-    /// Pulls every vehicleRecord matching `plate` and decodes it the same way
-    /// `ParkingViewModel.listenToRecords()` does. Static + nonisolated so it
-    /// can be safely invoked from any TaskGroup child without crossing actor
-    /// boundaries.
     nonisolated private static func fetchRecords(
         for plate: String,
         db: Firestore
@@ -161,4 +285,12 @@ final class BulkPlateLookupViewModel: ObservableObject {
             hitDailyCap: data["hitDailyCap"] as? Bool ?? false
         )
     }
+}
+
+// MARK: - NSCache box
+
+/// NSCache requires class values; wrap the Codable struct in a thin box.
+private final class CachedLookupBox {
+    let value: CachedLookup
+    init(_ value: CachedLookup) { self.value = value }
 }

--- a/sd-smart-parking/sd-smart-parking/Views/Gerente/BulkPlateLookupView.swift
+++ b/sd-smart-parking/sd-smart-parking/Views/Gerente/BulkPlateLookupView.swift
@@ -29,6 +29,10 @@ struct BulkPlateLookupView: View {
                     .padding(.horizontal)
                 }
 
+                if !vm.recentTerms.isEmpty {
+                    recentSearchesCard
+                }
+
                 inputCard
 
                 if let err = vm.lastError {
@@ -116,7 +120,8 @@ struct BulkPlateLookupView: View {
                     PlateResultCard(
                         plate: plate,
                         records: vm.resultsByPlate[plate] ?? [],
-                        isLoading: vm.inFlight.contains(plate)
+                        isLoading: vm.inFlight.contains(plate),
+                        servedFromCache: vm.cachedPlates.contains(plate)
                     )
                 }
 
@@ -127,6 +132,56 @@ struct BulkPlateLookupView: View {
             .padding(.horizontal)
             .padding(.bottom, 24)
         }
+    }
+
+    private var recentSearchesCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Label("Recent searches", systemImage: "clock.arrow.circlepath")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Button("Clear", role: .destructive) { vm.clearRecentTerms() }
+                    .font(.caption2)
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.red)
+            }
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(vm.recentTerms, id: \.self) { term in
+                        Button {
+                            inputFocused = false
+                            Task {
+                                await vm.rerun(
+                                    term: term,
+                                    isOnline: network.isConnected,
+                                    localFallback: parkingVM.vehicleRecords
+                                )
+                            }
+                        } label: {
+                            Text(displayLabel(for: term))
+                                .font(.caption)
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 6)
+                                .background(Color.blue.opacity(0.12))
+                                .foregroundStyle(.blue)
+                                .clipShape(Capsule())
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+        }
+        .padding(12)
+        .background(Color.white)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .padding(.horizontal)
+    }
+
+    private func displayLabel(for term: String) -> String {
+        let plates = vm.parsePlates(term)
+        if plates.count <= 2 { return plates.joined(separator: ", ") }
+        return "\(plates[0]), \(plates[1]) +\(plates.count - 2)"
     }
 
     private var orderedPlates: [String] {
@@ -157,12 +212,19 @@ private struct PlateResultCard: View {
     let plate: String
     let records: [VehicleRecord]
     let isLoading: Bool
+    let servedFromCache: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 8) {
                 Text(plate)
                     .font(.headline)
+                if servedFromCache {
+                    Image(systemName: "clock.arrow.circlepath")
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                        .accessibilityLabel("Served from cache")
+                }
                 Spacer()
                 if isLoading {
                     ProgressView().scaleEffect(0.75)


### PR DESCRIPTION
## What does this PR do?
Adds a **two-layer cache** around the bulk-plate-lookup feature: memory layer (`NSCache`) for instant within-session re-reads, disk layer (`KeyValueStore`) for persistence and offline use. Surfaces the last 10 search terms as one-tap capsules at the top of the screen.

## Why is this change needed?
Sprint 4 rubric point **(c)** requires at least one new feature with an explicit caching strategy. This feature delivers the standard two-layer pattern (memory + disk) but applied to a different domain than Juanes' analytics, so individual contribution is visible. It also turns the bulk-lookup screen into a useful offline tool — cached results survive restarts and serve instantly even without network.

## How was it implemented?
- `CachedLookup` Codable model (`plate`, `records`, `cachedAt`).
- `BulkPlateLookupViewModel` extended:
  - `NSCache<NSString, CachedLookupBox>` (`countLimit = 50`) wraps the value-type struct in a thin class box.
  - `KeyValueStore<String, CachedLookup>` (scope `diego.recent-lookups`) for disk persistence.
  - Read order **memory → disk → Firestore**. Writes go to both layers. Disk is trimmed to 50 newest entries after each write.
  - New `@Published cachedPlates: Set<String>` tracks which currently-shown results came from cache; cleared when the fresh Firestore result lands.
  - New `@Published recentTerms: [String]` (last 10 raw inputs, deduped, newest first) persisted via `UserDefaults` key `diego.recent-lookup-terms`. New `rerun(term:)` API.
- `BulkPlateLookupView` extended with:
  - "Recent searches" capsule strip + Clear button.
  - `clock.arrow.circlepath` badge on cards served from cache.

## Eventual connectivity
The cache layer IS the offline fallback for repeat searches. Offline + cache-hit serves instantly with the orange clock badge. Offline + cache-miss still falls back to bucketing `ParkingViewModel.vehicleRecords`. Online: cache shows first, fresh results replace it as TaskGroup children resolve.

## Related Issue
Closes #90

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Xcode 26.3, iPhone 17 simulator, iOS 26.0.
- `build_sim` via XcodeBuildMCP — succeeds, no new warnings introduced.
- Smoke: ran a bulk search, repeated it → instant cached render with orange clock badge, then fresh data replaced it. Airplane-mode + force-quit + relaunch → cached results still served.

## Checklist
- [x] Self-review of own code
- [x] Follows existing MVVM + `ObservableObject` + `@Published` pattern
- [x] Reuses existing infrastructure (`NSCache`, `KeyValueStore`)
- [x] No edits to `project.pbxproj`, `Info.plist`, or teammate code
- [x] No new third-party dependencies